### PR TITLE
Bring Cupid xml parsing level with v4 of schema 

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -596,13 +596,13 @@ typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
 name = "pydantic-settings"
-version = "2.0.2"
+version = "2.0.3"
 description = "Settings management using Pydantic"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pydantic_settings-2.0.2-py3-none-any.whl", hash = "sha256:6183a2abeab465d5a3ab69758e9a22d38b0cc2ba193f0b85f6971a252ea630f6"},
-    {file = "pydantic_settings-2.0.2.tar.gz", hash = "sha256:342337fff50b23585e807a86dec85037900972364435c55c2fc00d16ff080539"},
+    {file = "pydantic_settings-2.0.3-py3-none-any.whl", hash = "sha256:ddd907b066622bd67603b75e2ff791875540dc485b7307c4fffc015719da8625"},
+    {file = "pydantic_settings-2.0.3.tar.gz", hash = "sha256:962dc3672495aad6ae96a4390fac7e593591e144625e5112d359f8f67fb75945"},
 ]
 
 [package.dependencies]
@@ -859,13 +859,13 @@ files = [
 
 [[package]]
 name = "tox"
-version = "4.7.0"
+version = "4.8.0"
 description = "tox is a generic virtualenv management and test command line tool"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "tox-4.7.0-py3-none-any.whl", hash = "sha256:79399a3d4641d1fd15eb6bd62c2f35923988038bf0ecf37a688b5e7a767de7d7"},
-    {file = "tox-4.7.0.tar.gz", hash = "sha256:89120e1568c763924301cfde61ba7d4b5c4615eeb1086d5370deb03e9cf63c41"},
+    {file = "tox-4.8.0-py3-none-any.whl", hash = "sha256:4991305a56983d750a0d848a34242be290452aa88d248f1bf976e4036ee8b213"},
+    {file = "tox-4.8.0.tar.gz", hash = "sha256:2adacf435b12ccf10b9dfa9975d8ec0afd7cbae44d300463140d2117b968037b"},
 ]
 
 [package.dependencies]
@@ -911,12 +911,12 @@ SQLAlchemy = ">=1.4.25,<2.0.0"
 
 [[package]]
 name = "ukrdc-xsdata"
-version = "3.4.5"
+version = "4.0.0"
 description = ""
 optional = false
 python-versions = "*"
 files = [
-    {file = "ukrdc_xsdata-3.4.5-py3-none-any.whl", hash = "sha256:d2084fd01cc45228e5bc73703f86f9b825cfa112263da10bcf84294110dc53b3"},
+    {file = "ukrdc_xsdata-4.0.0-py3-none-any.whl", hash = "sha256:a60f729be8d0b3e98345cfdafe30dee030cee60846297907235d06dd8462700c"},
 ]
 
 [package.dependencies]
@@ -924,13 +924,13 @@ xsdata = "*"
 
 [[package]]
 name = "virtualenv"
-version = "20.24.2"
+version = "20.24.3"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "virtualenv-20.24.2-py3-none-any.whl", hash = "sha256:43a3052be36080548bdee0b42919c88072037d50d56c28bd3f853cbe92b953ff"},
-    {file = "virtualenv-20.24.2.tar.gz", hash = "sha256:fd8a78f46f6b99a67b7ec5cf73f92357891a7b3a40fd97637c27f854aae3b9e0"},
+    {file = "virtualenv-20.24.3-py3-none-any.whl", hash = "sha256:95a6e9398b4967fbcb5fef2acec5efaf9aa4972049d9ae41f95e0972a683fd02"},
+    {file = "virtualenv-20.24.3.tar.gz", hash = "sha256:e5c3b4ce817b0b328af041506a2a299418c98747c4b1e68cb7527e74ced23efc"},
 ]
 
 [package.dependencies]
@@ -944,13 +944,13 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 
 [[package]]
 name = "xsdata"
-version = "23.7"
+version = "23.8"
 description = "Python XML Binding"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "xsdata-23.7-py3-none-any.whl", hash = "sha256:ccfc72098275dcb65c558cf7850d71e01af3e1c212483f4df4e5d273f6d0e1dc"},
-    {file = "xsdata-23.7.tar.gz", hash = "sha256:8d79e9078d8ff4f8c4830ecda1208613a4b5e283a41e4cd304561bf6fca96aac"},
+    {file = "xsdata-23.8-py3-none-any.whl", hash = "sha256:3cf34ffb1ae35ac873e7eb53504e326d7997939f976a51814a57f77c8df8f09e"},
+    {file = "xsdata-23.8.tar.gz", hash = "sha256:55f03d4c88236f047266affe550ba0dd19476adfce6a01f3e0aefac7c8078e56"},
 ]
 
 [package.dependencies]
@@ -966,4 +966,4 @@ test = ["pre-commit", "pytest", "pytest-benchmark", "pytest-cov"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "5783175b2ca834e286898603a8c176143266953a13212a22a297281493592c02"
+content-hash = "2ae201feeb0c3a476b95bb5f85d9845517ff8d7ab486630f633a43f98371d691"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,12 @@ version = "0.1.1"
 [tool.poetry.dependencies]
 python = "^3.8"
 ukrdc-sqla = "^2.0.0"
-ukrdc-xsdata = "^3.3.0.post1"
 lxml = "^4.9.2"
 gitpython = "^3.1.31"
 pydantic = "^2.1.1"
 pydantic-settings = "^2.0.2"
 platformdirs = "^3.9.1"
+ukrdc-xsdata = "^4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 black = {version = "^22.10.0", allow-prereleases = true}

--- a/scripts/example_xml_validation.py
+++ b/scripts/example_xml_validation.py
@@ -19,6 +19,7 @@ def report_errors(file:str, schema_version:str):
         return
 
 #input_path = r"C:\Users\philip.main\Source\ins_files"
+#input_path = r"C:\Users\philip.main\Source\CCL_xml_v5\2023-07-26\corrected"
 input_path = r"scripts\xml_examples"
 
 xml_files = [item for item in Path(input_path).rglob("*.xml")]
@@ -30,9 +31,10 @@ csv_headers = ["file name", "schema version", "line", "error"]
 # Create a list to hold all errors
 all_errors = []
 
-schema_version = "3.3.0"
+schema_version = "4.0.0"
 # Run through and validate all example files against all available datasets
 for file in xml_files:
+    print(file)
     errors = report_errors(file, schema_version)
     if errors:
         # Append errors to the list

--- a/scripts/xml_examples/UKRDC_v3_3_0_pathalogical.xml
+++ b/scripts/xml_examples/UKRDC_v3_3_0_pathalogical.xml
@@ -1,0 +1,489 @@
+<ukrdc:PatientRecord xmlns:ukrdc="http://www.rixg.org.uk/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <SendingFacility channelName="UKRDCSampleExtract" channelId = "666" schemaVersion="3.4.5">ABC123</SendingFacility>
+    <SendingExtract>UKRDC</SendingExtract>
+    <Patient>
+        <PatientNumbers>
+            <PatientNumber>
+                <Number>AAA111B</Number>
+                <Organization>LOCALHOSP</Organization>
+                <NumberType>MRN</NumberType>
+            </PatientNumber>
+            <PatientNumber>
+                <Number>1111111111</Number>
+                <Organization>NHS</Organization>
+                <NumberType>NI</NumberType>
+            </PatientNumber>
+        </PatientNumbers>
+        <Names>
+            <Name use="L">
+                <Prefix>Mr</Prefix>
+                <Family>Sample</Family>
+                <Given>John</Given>
+            </Name>
+        </Names>
+        <BirthTime>2006-05-04T18:13:51.0</BirthTime>
+        <Gender>1</Gender>
+        <Addresses>
+            <Address use="H">
+                <FromTime>2006-05-04</FromTime>
+                <ToTime>2006-05-04</ToTime>
+                <Street>Street0</Street>
+                <Town>Town0</Town>
+                <County>County0</County>
+                <Postcode>BS10 5NB</Postcode>
+                <Country>
+                    <CodingStandard>ISO3166-1</CodingStandard>
+                    <Code>GBR</Code>
+                    <Description>Great Britain</Description>
+                </Country>
+            </Address>
+        </Addresses>
+        <ContactDetails>
+            <ContactDetail use="PRN">
+                <Value>0117 11111111</Value>
+            </ContactDetail>
+        </ContactDetails>
+        <CountryOfBirth>GBR</CountryOfBirth>
+        <FamilyDoctor>
+            <GPPracticeId>J11111</GPPracticeId>
+            <GPId>G2222222</GPId>
+            <Email>reception@villagegp.nhs.uk</Email>
+        </FamilyDoctor>
+        <EthnicGroup>
+            <CodingStandard>NHS_DATA_DICTIONARY</CodingStandard>
+            <Code>A</Code>
+            <Description>White - British</Description>
+        </EthnicGroup>
+        <Occupation>
+            <CodingStandard>NHS_DATA_DICTIONARY_EMPLOYMENT_STATUS</CodingStandard>
+            <Code>0l</Code>
+            <Description>Oompa Loompa at Willy Wonka's Chocolate Factory</Description>
+        </Occupation>
+        <BloodGroup>A</BloodGroup>
+        <BloodRhesus>POS</BloodRhesus>
+        <Death>false</Death>
+        <UpdatedOn>2006-05-04T18:13:51.0</UpdatedOn>
+        <ExternalId>1122334455</ExternalId>
+    </Patient>
+    <LabOrders start="2021-01-01" stop="2021-04-01">
+        <LabOrder>
+            <ReceivingLocation>
+                <CodingStandard>RR1+</CodingStandard>
+                <Code>ABC123</Code>
+                <Description>Test Hospital</Description>
+            </ReceivingLocation>
+            <PlacerId>PlacerId0</PlacerId>
+            <FillerId>FillerId0</FillerId>
+            <OrderedBy>
+                <CodingStandard>ODS</CodingStandard>
+                <Code>AA1122</Code>
+                <Description>Test Hospital 2</Description>
+            </OrderedBy>
+            <OrderItem>
+                <CodingStandard>LOCAL</CodingStandard>
+                <Code>11223344</Code>
+                <Description>Full Blood Test</Description>
+            </OrderItem>
+            <SpecimenCollectedTime>2006-05-04T18:13:51.0</SpecimenCollectedTime>
+            <SpecimenReceivedTime>2006-05-04T18:13:51.0</SpecimenReceivedTime>
+            <SpecimenSource>BLOOD</SpecimenSource>
+
+            <ResultItems>
+                <ResultItem>
+                    <EnteredOn>2006-05-04T18:13:51.0</EnteredOn>
+                    <PrePost>PRE</PrePost>
+                    <ServiceId>
+                        <CodingStandard>UKRR</CodingStandard>
+                        <Code>QBLA1</Code>
+                        <Description>Serum Creatinine</Description>
+                    </ServiceId>
+                    <ResultValue>78</ResultValue>
+                    <ResultValueUnits>mmol/L</ResultValueUnits>
+                    <ReferenceRange>10-1000</ReferenceRange>
+                    <ObservationTime>2006-05-04T18:13:51.0</ObservationTime>
+                </ResultItem>
+                <ResultItem>
+                    <EnteredOn>2006-05-04T18:13:51.0</EnteredOn>
+                    <PrePost>PRE</PrePost>
+                    <ServiceId>
+                        <CodingStandard>UKRR</CodingStandard>
+                        <Code>QBLF7</Code>
+                        <Description>Serum B12</Description>
+                    </ServiceId>
+                    <ResultValue>100</ResultValue>
+                    <ResultValueUnits>ng/L</ResultValueUnits>
+                    <ReferenceRange>0-10000</ReferenceRange>
+                    <ObservationTime>2006-05-04T18:13:51.0</ObservationTime>
+                </ResultItem>
+            </ResultItems>
+
+            <EnteredOn>2006-05-04T18:13:51.0</EnteredOn>
+            <EnteredAt>
+                <CodingStandard>RR1+</CodingStandard>
+                <Code>ABC123</Code>
+                <Description>Test Hospital</Description>
+            </EnteredAt>
+            <EnteringOrganization>
+                <CodingStandard>RR1+</CodingStandard>
+                <Code>ABC123</Code>
+                <Description>Test Hospital</Description>
+            </EnteringOrganization>
+            <UpdatedOn>2006-05-04T18:13:51.0</UpdatedOn>
+            <ExternalId>9999999999</ExternalId>
+        </LabOrder>
+    </LabOrders>
+
+    <Observations start="2021-01-01" stop="2021-04-01">
+        <Observation>
+            <ObservationTime>2006-05-04T18:13:51.0</ObservationTime>
+            <ObservationCode>
+                <CodingStandard>UKRR</CodingStandard>
+                <Code>QBLG3</Code>
+                <Description>Systolic BP</Description>
+            </ObservationCode>
+            <ObservationValue>150</ObservationValue>
+            <ObservationUnits>mmHg</ObservationUnits>
+            <PrePost>PRE</PrePost>
+            <EnteredAt>
+                <CodingStandard>RR1+</CodingStandard>
+                <Code>ABC123</Code>
+                <Description>Test Hospital</Description>
+            </EnteredAt>
+            <EnteringOrganization>
+                <CodingStandard>RR1+</CodingStandard>
+                <Code>ABC123</Code>
+                <Description>Test Hospital</Description>
+            </EnteringOrganization>
+            <UpdatedOn>2006-05-04T18:13:51.0</UpdatedOn>
+            <ExternalId>88888888</ExternalId>
+        </Observation>
+        <Observation>
+            <ObservationTime>2006-05-04T18:13:51.0</ObservationTime>
+            <ObservationCode>
+                <CodingStandard>UKRR</CodingStandard>
+                <Code>QBLG4</Code>
+                <Description>Diastolic BP</Description>
+            </ObservationCode>
+            <ObservationValue>100</ObservationValue>
+            <ObservationUnits>mmHg</ObservationUnits>
+            <PrePost>PRE</PrePost>
+            <EnteredAt>
+                <CodingStandard>RR1+</CodingStandard>
+                <Code>ABC123</Code>
+                <Description>Test Hospital</Description>
+            </EnteredAt>
+            <EnteringOrganization>
+                <CodingStandard>RR1+</CodingStandard>
+                <Code>ABC123</Code>
+                <Description>Test Hospital</Description>
+            </EnteringOrganization>
+            <UpdatedOn>2006-05-04T18:13:51.0</UpdatedOn>
+            <ExternalId>7777777777</ExternalId>
+        </Observation>
+    </Observations>
+
+    <Diagnoses>
+        <Diagnosis>
+            <Diagnosis>
+                <CodingStandard>SNOMED</CodingStandard>
+                <Code>414545008</Code>
+                <Description>Ischaemic Heart Disease</Description>
+            </Diagnosis>
+            <IdentificationTime>2006-05-04T18:13:51.0</IdentificationTime>
+            <OnsetTime>2006-05-04T18:13:51.0</OnsetTime>
+            <EnteredOn>2006-05-04T18:13:51.0</EnteredOn>
+            <EnteredAt>
+                <CodingStandard>RR1+</CodingStandard>
+                <Code>ABC123</Code>
+                <Description>Test Hospital</Description>
+            </EnteredAt>
+            <UpdatedOn>2006-05-04T18:13:51.0</UpdatedOn>
+            <ExternalId>5555555555</ExternalId>
+        </Diagnosis>
+        <Diagnosis>
+            <Diagnosis>
+                <CodingStandard>SNOMED</CodingStandard>
+                <Code>235856003</Code>
+                <Description>Liver Disease</Description>
+            </Diagnosis>
+            <IdentificationTime>2006-05-04T18:13:51.0</IdentificationTime>
+            <OnsetTime>2006-05-04T18:13:51.0</OnsetTime>
+            <EnteredOn>2006-05-04T18:13:51.0</EnteredOn>
+            <EnteredAt>
+                <CodingStandard>RR1+</CodingStandard>
+                <Code>ABC123</Code>
+                <Description>Test Hospital 1</Description>
+            </EnteredAt>
+            <UpdatedOn>2006-05-04T18:13:51.0</UpdatedOn>
+            <ExternalId>778787876878</ExternalId>
+        </Diagnosis>
+        <CauseOfDeath>
+            <Diagnosis>
+                <CodingStandard>EDTA_COD</CodingStandard>
+                <Code>14</Code>
+                <Description>Other causes of cardiac failure</Description>
+            </Diagnosis>
+            <Comments>Comments15</Comments>
+            <EnteredOn>2006-05-04T18:13:51.0</EnteredOn>
+            <UpdatedOn>2006-05-04T18:13:51.0</UpdatedOn>
+            <ExternalId>211111221</ExternalId>
+        </CauseOfDeath>
+        <RenalDiagnosis>
+            <Diagnosis>
+                <CodingStandard>EDTA2</CodingStandard>
+                <Code>13</Code>
+                <Description>Dense deposite disease, membrano-prolif. GN Type II</Description>
+            </Diagnosis>
+            <Comments>Comments16</Comments>
+            <IdentificationTime>2006-05-04T18:13:51.0</IdentificationTime>
+            <OnsetTime>2006-05-04T18:13:51.0</OnsetTime>
+            <EnteredOn>2006-05-04T18:13:51.0</EnteredOn>
+            <UpdatedOn>2006-05-04T18:13:51.0</UpdatedOn>
+            <ExternalId>433444333222</ExternalId>
+        </RenalDiagnosis>
+    </Diagnoses>
+
+    <Medications>
+        <Medication>
+            <FromTime>2006-05-04T18:13:51.0</FromTime>
+            <ToTime>2006-05-04T18:13:51.0</ToTime>
+            <Route>
+                <CodingStandard>RR22</CodingStandard>
+                <Code>1</Code>
+                <Description>Oral</Description>
+            </Route>
+            <DrugProduct>
+                <Generic>Generic0</Generic>
+                <LabelName>LabelName0</LabelName>
+                <Form>
+                    <CodingStandard>SNOMED</CodingStandard>
+                    <Code>Code60</Code>
+                    <Description>Description60</Description>
+                </Form>
+                <StrengthUnits>
+                    <CodingStandard>CF_RR23</CodingStandard>
+                    <Code>l</Code>
+                    <Description>Description61</Description>
+                </StrengthUnits>
+            </DrugProduct>
+            <Frequency>Frequency0</Frequency>
+            <Comments>Comments17</Comments>
+            <DoseQuantity>0</DoseQuantity>
+            <DoseUoM>
+                <CodingStandard>CodingStandard62</CodingStandard>
+                <Code>Code62</Code>
+                <Description>Description62</Description>
+            </DoseUoM>
+            <Indication>Indication0</Indication>
+            <EncounterNumber>EncounterNumber2</EncounterNumber>
+            <UpdatedOn>2006-05-04T18:13:51.0</UpdatedOn>
+            <ExternalId>ExternalId15</ExternalId>
+        </Medication>
+    </Medications>
+
+    <Procedures>
+        <DialysisSessions>
+            <DialysisSession>
+                <ProcedureType>
+                    <CodingStandard>SNOMED</CodingStandard>
+                    <Code>302497006</Code>
+                    <Description>Haemodialysis</Description>
+                </ProcedureType>
+                <ProcedureTime>2006-05-04T18:13:51.0</ProcedureTime>
+                <EnteredBy>
+                    <CodingStandard>ODS</CodingStandard>
+                    <Code>ABC123</Code>
+                    <Description>Dr Foster</Description>
+                </EnteredBy>
+                <EnteredAt>
+                    <CodingStandard>RR1+</CodingStandard>
+                    <Code>ABC123</Code>
+                    <Description>Test Hospital</Description>
+                </EnteredAt>
+                <UpdatedOn>2006-05-04T18:13:51.0</UpdatedOn>
+                <ExternalId>787878787</ExternalId>
+                <Attributes>
+                    <QHD19>Y</QHD19>
+                    <QHD20>NLN</QHD20>
+                    <QHD21>BB</QHD21>
+                    <QHD22>Y</QHD22>
+                    <QHD30>100</QHD30>
+                    <QHD31>200</QHD31>
+                    <QHD32>300</QHD32>
+                    <QHD33>U</QHD33>
+                </Attributes>
+            </DialysisSession>
+            <DialysisSession>
+                <ProcedureType>
+                    <CodingStandard>SNOMED</CodingStandard>
+                    <Code>Code82</Code>
+                    <Description>Description82</Description>
+                </ProcedureType>
+                <Clinician>
+                    <CodingStandard>ODS</CodingStandard>
+                    <Code>Code83</Code>
+                    <Description>Description83</Description>
+                </Clinician>
+                <ProcedureTime>2006-05-04T18:13:51.0</ProcedureTime>
+                <EnteredBy>
+                    <CodingStandard>ODS</CodingStandard>
+                    <Code>Code84</Code>
+                    <Description>Description84</Description>
+                </EnteredBy>
+                <EnteredAt>
+                    <CodingStandard>ODS</CodingStandard>
+                    <Code>Code85</Code>
+                    <Description>Description85</Description>
+                </EnteredAt>
+                <UpdatedOn>2006-05-04T18:13:51.0</UpdatedOn>
+                <ExternalId>ExternalId20</ExternalId>
+                <Attributes>
+                    <QHD19>Y</QHD19>
+                    <QHD20>NLN</QHD20>
+                    <QHD21>BB</QHD21>
+                    <QHD22>Y</QHD22>
+                    <QHD30>100</QHD30>
+                    <QHD31>200</QHD31>
+                    <QHD32>300</QHD32>
+                    <QHD33>L</QHD33>
+                </Attributes>
+            </DialysisSession>
+        </DialysisSessions>
+        <Transplant>
+            <ProcedureType>
+                <CodingStandard>SNOMED</CodingStandard>
+                <Code>19647005</Code>
+                <Description>PEX</Description>
+            </ProcedureType>
+            <ProcedureTime>2006-05-04T18:13:51.0</ProcedureTime>
+            <EnteredBy>
+                <CodingStandard>ODS</CodingStandard>
+                <Code>ABC123</Code>
+                <Description>Dr Foster</Description>
+            </EnteredBy>
+            <EnteredAt>
+                <CodingStandard>RR1+</CodingStandard>
+                <Code>ABC123</Code>
+                <Description>Test Hospital</Description>
+            </EnteredAt>
+            <UpdatedOn>2006-05-04T18:13:51.0</UpdatedOn>
+            <ExternalId>1222333444</ExternalId>
+            <Attributes>
+                <TRA64>2006-05-04T18:13:51.0</TRA64>
+                <TRA65>14</TRA65>
+                <TRA66>2006-05-04T18:13:51.0</TRA66>
+                <TRA69>2006-05-04T18:13:51.0</TRA69>
+                <TRA76>21</TRA76>
+                <TRA77>DBD</TRA77>
+                <TRA78>NEG</TRA78>
+                <TRA79>NEG</TRA79>
+                <TRA80>27</TRA80>
+                <TRA8A>1</TRA8A>
+                <TRA81>NEG</TRA81>
+                <TRA82>NEG</TRA82>
+                <TRA83>0</TRA83>
+                <TRA84>0</TRA84>
+                <TRA85>0</TRA85>
+                <TRA86>Y</TRA86>
+                <TRA87>Y</TRA87>
+                <TRA88>Y</TRA88>
+                <TRA89>Y</TRA89>
+                <TRA90>Y</TRA90>
+                <TRA91>90</TRA91>
+                <TRA92>Y</TRA92>
+                <TRA93>0</TRA93>
+                <TRA94>1</TRA94>
+                <TRA95>2</TRA95>
+                <TRA96>Y</TRA96>
+                <TRA97>10</TRA97>
+                <TRA98>10</TRA98>
+            </Attributes>
+        </Transplant>
+        <VascularAccess>
+            <ProcedureType>
+                <CodingStandard>SNOMED</CodingStandard>
+                <Code>27929005</Code>
+                <Description>Construction of arteriovenous fistula</Description>
+            </ProcedureType>
+            <ProcedureTime>2006-05-04T18:13:51.0</ProcedureTime>
+            <EnteredBy>
+                <CodingStandard>ODS</CodingStandard>
+                <Code>ABC123</Code>
+                <Description>Dr Foster</Description>
+            </EnteredBy>
+            <EnteredAt>
+                <CodingStandard>RR1+</CodingStandard>
+                <Code>ABC123</Code>
+                <Description>Test Hospital</Description>
+            </EnteredAt>
+            <UpdatedOn>2006-05-04T18:13:51.0</UpdatedOn>
+            <ExternalId>1111111111</ExternalId>
+            <Attributes>
+                <ACC19>2006-05-04T18:13:51.0</ACC19>
+                <ACC20>2006-05-04T18:13:51.0</ACC20>
+                <ACC21>2006-05-04T18:13:51.0</ACC21>
+                <ACC22>100</ACC22>
+                <ACC30>1</ACC30>
+                <ACC40>300</ACC40>
+            </Attributes>
+        </VascularAccess>
+    </Procedures>
+
+    <Documents>
+        <Document>
+            <DocumentTime>2006-05-04T18:13:51.0</DocumentTime>
+            <NoteText>This is some plain text.</NoteText>
+            <DocumentName>GP Letter</DocumentName>
+            <FileType>text/plain</FileType>
+            <FileName>letter.txt</FileName>
+            <UpdatedOn>2006-05-04T18:13:51.0</UpdatedOn>
+            <ExternalId>1111111111</ExternalId>
+        </Document>
+    </Documents>
+
+    <Encounters>
+        <Treatment>
+            <FromTime>2006-05-04</FromTime>
+            <ToTime>2021-05-04</ToTime>
+            <HealthCareFacility>
+                <CodingStandard>RR1+</CodingStandard>
+                <Code>ABC123</Code>
+                <Description>Test Hospital</Description>
+            </HealthCareFacility>
+            <AdmitReason>
+                <CodingStandard>CF_RR7_TREATMENT</CodingStandard>
+                <Code>1</Code>
+                <Description>Haemodialysis</Description>
+            </AdmitReason>
+            <AdmissionSource>
+                <CodingStandard>RR1+</CodingStandard>
+                <Code>ABROAD</Code>
+                <Description>ABROAD</Description>
+            </AdmissionSource>
+            <DischargeReason>
+                <CodingStandard>CF_RR7_DISCHARGE</CodingStandard>
+                <Code>38</Code>
+                <Description>Patient Transferred Out</Description>
+            </DischargeReason>
+            <DischargeLocation>
+                <CodingStandard>RR1+</CodingStandard>
+                <Code>AAA111</Code>
+                <Description>Another Hospital</Description>
+            </DischargeLocation>
+            <Attributes>
+                <HDP01>100</HDP01>
+                <HDP02>200</HDP02>
+                <HDP03>300</HDP03>
+                <HDP04>400</HDP04>
+                <QBL05>HOSP</QBL05>
+                <QBL06>1</QBL06>
+                <QBL07>Y</QBL07>
+                <ERF61>1</ERF61>
+                <PAT35>2006-05-04T18:13:51.0</PAT35>
+            </Attributes>
+            <UpdatedOn>2006-05-04T18:13:51.0</UpdatedOn>
+            <ExternalId>3343433432234</ExternalId>
+        </Treatment>
+    </Encounters>
+
+</ukrdc:PatientRecord>

--- a/src/ukrdc_cupid/core/store/models/ukrdc.py
+++ b/src/ukrdc_cupid/core/store/models/ukrdc.py
@@ -20,6 +20,7 @@ import ukrdc_xsdata.ukrdc.social_histories as xsd_social_history  # type: ignore
 import ukrdc_xsdata.ukrdc.family_histories as xsd_family_history  # type: ignore
 import ukrdc_xsdata.ukrdc.allergies as xsd_allergy  # type: ignore
 import ukrdc_xsdata.ukrdc.diagnoses as xsd_diagnosis  # type: ignore
+import ukrdc_xsdata.ukrdc.dialysis_prescriptions as xsd_prescriptions  # type: ignore
 import ukrdc_xsdata.ukrdc.medications as xsd_medication  # type: ignore
 import ukrdc_xsdata.ukrdc.procedures as xsd_procedure  # type: ignore
 import ukrdc_xsdata.ukrdc.dialysis_sessions as xsd_dialysis_session  # type: ignore
@@ -195,39 +196,57 @@ class LabOrder(Node):
     def map_xml_to_tree(self):
 
         self.add_item("placerid", self.xml.placer_id, optional=False)
-        self.add_item("fillerid", self.xml.filler_id)
-        self.add_item("specimencollectedtime", self.xml.specimen_collected_time)
-        self.add_item("status", self.xml.status)
-        self.add_item("specimenreceivedtime", self.xml.specimen_received_time)
+        self.add_item("fillerid", self.xml.filler_id, optional=True)
+        self.add_item(
+            "specimencollectedtime", self.xml.specimen_collected_time, optional=True
+        )
+        self.add_item("status", self.xml.status, optional=True)
+        self.add_item(
+            "specimenreceivedtime", self.xml.specimen_received_time, optional=True
+        )
 
-        self.add_item("specimensource", self.xml.specimen_source)
-        self.add_item("duration", self.xml.duration)
-        self.add_item("enteredon", self.xml.entered_on)
-        self.add_item("updatedon", self.xml.updated_on)
-        self.add_item("externalid", self.xml.external_id)
+        self.add_item("specimensource", self.xml.specimen_source, optional=True)
+        self.add_item("duration", self.xml.duration, optional=True)
+        self.add_item("enteredon", self.xml.entered_on, optional=True)
+        self.add_item("updatedon", self.xml.updated_on, optional=True)
+        self.add_item("externalid", self.xml.external_id, optional=True)
 
         self.add_code(
             "receivinglocationcode",
             "receivinglocationdesc",
             "receivinglocationcodestd",
             self.xml.receiving_location,
+            optional=True,
         )
         self.add_code(
-            "orderedbycode", "orderedbycodestd", "orderedbydesc", self.xml.ordered_by
+            "orderedbycode",
+            "orderedbycodestd",
+            "orderedbydesc",
+            self.xml.ordered_by,
+            optional=True,
         )
 
         self.add_code(
-            "orderitemcode", "orderitemcodestd", "orderitemdesc", self.xml.order_item
+            "orderitemcode",
+            "orderitemcodestd",
+            "orderitemdesc",
+            self.xml.order_item,
+            optional=True,
         )
         self.add_code(
             "ordercategorycode",
             "ordercategorycodestd",
             "ordercategorydesc",
             self.xml.order_category,
+            optional=True,
         )
 
         self.add_code(
-            "prioritycode", "prioritycodestd", "prioritydesc", self.xml.priority
+            "prioritycode",
+            "prioritycodestd",
+            "prioritydesc",
+            self.xml.priority,
+            optional=True,
         )
 
         # self.add_patient_class(self.xml.patient_class)
@@ -236,16 +255,22 @@ class LabOrder(Node):
             "pateintclassdesc",
             "patientclasscodestd",
             self.xml.patient_class,
+            optional=True,
         )
 
         self.add_code(
-            "enteredatcode", "enteredatdesc", "enteredatcodestd", self.xml.entered_at
+            "enteredatcode",
+            "enteredatdesc",
+            "enteredatcodestd",
+            self.xml.entered_at,
+            optional=True,
         )
         self.add_code(
             "enteringorganizationcode",
             "enteringorganizationcodestd",
             "enteringorganizationdesc",
             self.xml.entering_organization,
+            optional=True,
         )
 
         self.add_children(ResultItem, "result_items.result_item")
@@ -442,7 +467,7 @@ class SocialHistory(Node):
             self.xml.social_habit,
             optional=False,
         )
-        self.add_item("updatedon", self.xml.updated_on)
+        self.add_item("updatedon", self.xml.updated_on, optional=True)
         self.add_item("externalid", self.xml.external_id)
 
     def transformer(self):
@@ -459,27 +484,27 @@ class FamilyHistory(Node):
             "familymembercodestd",
             "familymemberdesc",
             self.xml.family_member,
-            optional=False,
+            optional=True,
         )
         self.add_code(
             "diagnosiscode",
             "diagnosiscodingstandard",
             "diagnosisdesc",
             self.xml.diagnosis,
-            optional=False,
+            optional=True,
         )
-        self.add_item("notetext", self.xml.note_text)
+        self.add_item("notetext", self.xml.note_text, optional=True)
         self.add_code(
             "enteredatcode",
             "enteredatcodestd",
             "enteredatdesc",
             self.xml.entered_at,
-            optional=False,
+            optional=True,
         )
-        self.add_item("fromtime", self.xml.from_time)
-        self.add_item("totime", self.xml.to_time)
-        self.add_item("updatedon", self.xml.updated_on)
-        self.add_item("externalid", self.xml.external_id)
+        self.add_item("fromtime", self.xml.from_time, optional=True)
+        self.add_item("totime", self.xml.to_time, optional=True)
+        self.add_item("updatedon", self.xml.updated_on, optional=True)
+        self.add_item("externalid", self.xml.external_id, optional=True)
 
     def transformer(self):
         pass
@@ -502,24 +527,33 @@ class Allergy(Node):
             "allergycategorycodestd",
             "allergycategorydesc",
             self.xml.allergy_category,
-            optional=False,
+            optional=True,
         )
         self.add_code(
             "severitycode",
             "severitycodestd",
             "severitydesc",
             self.xml.severity,
-            optional=False,
+            optional=True,
         )
         self.add_code(
-            "cliniciancode", "cliniciancodestd", "cliniciandesc", self.xml.clinician
+            "cliniciancode",
+            "cliniciancodestd",
+            "cliniciandesc",
+            self.xml.clinician,
+            optional=True,
         )
-        self.add_item("discoverytime", self.xml.discovery_time)
-        self.add_item("confirmedtime", self.xml.confirmed_time)
-        self.add_item("comments", self.xml.comments)
-        self.add_item("inactivetime", self.xml.inactive_time)
-        self.add_item("freetextallergy", self.xml.free_text_allergy)
-        self.add_item("qualifyingdetails", self.xml.qualifying_details)
+        self.add_item("discoverytime", self.xml.discovery_time, optional=True)
+        self.add_item("confirmedtime", self.xml.confirmed_time, optional=True)
+        self.add_item("comments", self.xml.comments, optional=True)
+        self.add_item("inactivetime", self.xml.inactive_time, optional=True)
+        self.add_item("freetextallergy", self.xml.free_text_allergy, optional=True)
+        self.add_item("qualifyingdetails", self.xml.qualifying_details, optional=True)
+
+        # common metadata
+        self.add_item("updatedon", self.xml.updated_on, optional=True)
+        # there is an update_date, actioncode here not sure what it does
+        self.add_item("externalid", self.xml.external_id, optional=True)
 
     def transformer(self):
         pass
@@ -543,24 +577,22 @@ class Diagnosis(Node):
             "diagnosiscodestd",
             "diagnosisdesc",
             self.xml.diagnosis,
-            optional=True,
+            optional=False,
         )
 
-        self.add_code(
-            "enteredatcode",
-            "enteredatcodestd",
-            "enteredatdesc",
-            self.xml.entered_at,
-            optional=True,
-        )
+        # TODO: Add biopsy performed when supported by the database.
 
-        self.add_item("diagnosistype", self.xml.diagnosis_type)
-        self.add_item("comments", self.xml.comments)
-        self.add_item("identificationtime", self.xml.identification_time)
-        self.add_item("onsettime", self.xml.onset_time)
-        self.add_item("enteredon", self.xml.entered_on)
-        self.add_item("encounternumber", self.xml.encounter_number)
-        self.add_item("verificationstatus", self.xml.verification_status)
+        self.add_item("diagnosistype", self.xml.diagnosis_type, optional=True)
+        self.add_item("comments", self.xml.comments, optional=True)
+        self.add_item("identificationtime", self.xml.identification_time, optional=True)
+        self.add_item("onsettime", self.xml.onset_time, optional=True)
+        self.add_item("enteredon", self.xml.entered_on, optional=True)
+        self.add_item("encounternumber", self.xml.encounter_number, optional=True)
+        self.add_item("verificationstatus", self.xml.verification_status, optional=True)
+
+        # common metadata
+        self.add_item("updatedon", self.xml.updated_on, optional=True)
+        self.add_item("externalid", self.xml.external_id, optional=True)
 
     def transformer(self):
         pass
@@ -571,24 +603,27 @@ class CauseOfDeath(Node):
         super().__init__(xml, sqla.CauseOfDeath)
 
     def map_xml_to_tree(self):
-        self.add_item("diagnosistype", self.xml.diagnosis_type)
-
-        self.add_code(
-            "diagnosingcliniciancode",
-            "diagnosingcliniciancodestd",
-            "diagnosingcliniciandesc",
-            self.xml.diagnosing_clinician,
-        )
+        self.add_item("diagnosistype", self.xml.diagnosis_type, optional=False)
 
         self.add_code(
             "diagnosiscode",
             "diagnosiscodestd",
             "diagnosisdesc",
             self.xml.diagnosis,
+            optional=False,
         )
 
-        self.add_item("comments", self.xml.comments)
-        self.add_item("enteredon", self.xml.entered_on)
+        self.add_item("comments", self.xml.comments, optional=True)
+        if self.xml.verification_status:
+            print(
+                "Cause of Death verification status not currently supported by the UKRDC database"
+            )
+
+        self.add_item("enteredon", self.xml.entered_on, optional=True)
+
+        # common metadata
+        self.add_item("updatedon", self.xml.updated_on, optional=True)
+        self.add_item("externalid", self.xml.external_id, optional=True)
 
     def transformer(self, pid: Optional[str], **kwargs):
         pass
@@ -599,14 +634,14 @@ class RenalDiagnosis(Node):
         super().__init__(xml, sqla.RenalDiagnosis)
 
     def map_xml_to_tree(self):
-        self.add_item("diagnosistype", self.xml.diagnosis_type)
+        self.add_item("diagnosistype", self.xml.diagnosis_type, optional=False)
 
         self.add_code(
             "diagnosingcliniciancode",
             "diagnosingcliniciancodestd",
             "diagnosingcliniciandesc",
             self.xml.diagnosing_clinician,
-            optional=False,
+            optional=True,
         )
 
         self.add_code(
@@ -617,15 +652,32 @@ class RenalDiagnosis(Node):
             optional=False,
         )
 
-        self.add_item("comments", self.xml.comments)
-        self.add_item("identificationtime", self.xml.identification_time)
-        self.add_item("onsettime", self.xml.onset_time)
-        self.add_item("enteredon", self.xml.entered_on)
+        self.add_item("comments", self.xml.comments, optional=True)
+        self.add_item("identificationtime", self.xml.identification_time, optional=True)
+        self.add_item("onsettime", self.xml.onset_time, optional=True)
+        self.add_item("enteredon", self.xml.entered_on, optional=True)
 
-        # biopsyperformed and verification status will need to be added when the database supports them
+        # common metadata
+        self.add_item("updatedon", self.xml.updated_on, optional=True)
+        self.add_item("externalid", self.xml.external_id, optional=True)
+
+        if self.xml.verification_status:
+            print("Cause of Death verification status not currently supported")
+
+        if self.xml.biopsy_performed:
+            print("Biopsy performed status not currently supported")
 
     def transformer(self):
         pass
+
+
+class DialysisPrescription(Node):
+    def __init__(self, xml: xsd_prescriptions.DialysisPrescription):
+        super().__init__(xml, None)
+
+    def map_xml_to_tree(self):
+        if self.xml.dialysis_session:
+            print("Loading dialysis sessions not currently supported")
 
 
 class Medication(Node):
@@ -633,47 +685,65 @@ class Medication(Node):
         super().__init__(xml, sqla.Medication)
 
     def add_drug_product(self):
-        if self.xml.drug_product:
-            self.add_item("drugproductgeneric", self.xml.drug_product.generic)
-            self.add_item("drugproductlabelname", self.xml.drug_product.label_name)
-            self.add_code(
-                "drugproductformcode",
-                "drugproductformcodestd",
-                "drugproductformdesc",
-                self.xml.drug_product.form,
-            )
-            self.add_code(
-                "drugproductstrengthunitscode",
-                "drugproductstrengthunitscodestd",
-                "drugproductstrengthunitsdesc",
-                self.xml.drug_product.strength_units,
-            )
+
+        self.add_code(
+            "drugproductidcode",
+            "drugproductidcodestd",
+            "drugproductiddesc",
+            self.xml.drug_product.id,
+            optional=True,
+        )
+        self.add_item(
+            "drugproductgeneric", self.xml.drug_product.generic, optional=False
+        )
+        self.add_item(
+            "drugproductlabelname", self.xml.drug_product.label_name, optional=True
+        )
+        self.add_code(
+            "drugproductformcode",
+            "drugproductformcodestd",
+            "drugproductformdesc",
+            self.xml.drug_product.form,
+            optional=True,
+        )
+        self.add_code(
+            "drugproductstrengthunitscode",
+            "drugproductstrengthunitscodestd",
+            "drugproductstrengthunitsdesc",
+            self.xml.drug_product.strength_units,
+            optional=True,
+        )
 
     def map_xml_to_tree(self):
-        self.add_item("prescriptionnumber", self.xml.prescription_number)
-        self.add_item("fromtime", self.xml.from_time)
-        self.add_item("totime", self.xml.to_time)
-        self.add_code(
-            "orderedbycode", "orderedbycodestd", "orderedbydesc", self.xml.ordered_by
-        )
+        self.add_item("prescriptionnumber", self.xml.prescription_number, optional=True)
+        self.add_item("fromtime", self.xml.from_time, optional=True)
+        self.add_item("totime", self.xml.to_time, optional=True)
+
         self.add_code(
             "enteringorganizationcode",
             "enteringorganizationcodestd",
             "enteringorganizationdesc",
             self.xml.entering_organization,
+            optional=True,
         )
-        self.add_code("routecode", "routecodestd", "routedesc", self.xml.route)
-        self.add_drug_product()
-        self.add_item("frequency", self.xml.frequency)
-        self.add_item("commenttext", self.xml.comments)
-        self.add_item("dosequantity", self.xml.dose_quantity)
         self.add_code(
-            "doseuomcode", "doseuomcodestd", "doseuomdesc", self.xml.dose_uo_m
+            "routecode", "routecodestd", "routedesc", self.xml.route, optional=True
         )
-        self.add_item("indication", self.xml.indication)
-        self.add_item("encounternumber", self.xml.encounter_number)
-        self.add_item("updatedon", self.xml.updated_on)
-        self.add_item("externalid", self.xml.external_id)
+        self.add_drug_product()
+        self.add_item("frequency", self.xml.frequency, optional=True)
+        self.add_item("commenttext", self.xml.comments, optional=True)
+        self.add_item("dosequantity", self.xml.dose_quantity, optional=True)
+        self.add_code(
+            "doseuomcode",
+            "doseuomcodestd",
+            "doseuomdesc",
+            self.xml.dose_uo_m,
+            optional=True,
+        )
+        self.add_item("indication", self.xml.indication, optional=True)
+        self.add_item("encounternumber", self.xml.encounter_number, optional=True)
+        self.add_item("updatedon", self.xml.updated_on, optional=True)
+        self.add_item("externalid", self.xml.external_id, optional=True)
 
     def transformer(self):
         pass
@@ -691,28 +761,26 @@ class Procedure(Node):
             self.xml.procedure_type,
             optional=False,
         )
-        self.add_code(
-            "cliniciancode",
-            "cliniciancodestd",
-            "cliniciandesc",
-            self.xml.clinician,
-            optional=False,
-        )
+
         self.add_item("proceduretime", self.xml.procedure_time, optional=False)
         self.add_code(
             "enteredbycode",
             "enteredbycodestd",
             "enteredbydesc",
             self.xml.entered_by,
-            optional=False,
+            optional=True,
         )
         self.add_code(
             "enteredatcode",
             "enteredatcodestd",
             "enteredatdesc",
             self.xml.entered_at,
-            optional=False,
+            optional=True,
         )
+
+        # common metadata
+        self.add_item("updatedon", self.xml.updated_on, optional=True)
+        self.add_item("externalid", self.xml.external_id, optional=True)
 
     def transformer(self):
         pass
@@ -722,17 +790,6 @@ class DialysisSession(Node):
     def __init__(self, xml: xsd_dialysis_session.DialysisSession):
         super().__init__(xml, sqla.DialysisSession)
 
-    def add_attributes(self):
-        if self.xml.attributes:
-            self.add_item("qhd19", self.xml.attributes.qhd19)
-            self.add_item("qhd20", self.xml.attributes.qhd20)
-            self.add_item("qhd21", self.xml.attributes.qhd21)
-            self.add_item("qhd22", self.xml.attributes.qhd22)
-            self.add_item("qhd30", self.xml.attributes.qhd30)
-            self.add_item("qhd31", self.xml.attributes.qhd31)
-            self.add_item("qhd32", self.xml.attributes.qhd32)
-            self.add_item("qhd33", self.xml.attributes.qhd33)
-
     def map_xml_to_tree(self):
         self.add_code(
             "proceduretypecode",
@@ -741,30 +798,27 @@ class DialysisSession(Node):
             self.xml.procedure_type,
             optional=False,
         )
-        self.add_code(
-            "cliniciancode",
-            "cliniciancodestd",
-            "cliniciandesc",
-            self.xml.clinician,
-            optional=False,
-        )
         self.add_item("proceduretime", self.xml.procedure_time, optional=False)
         self.add_code(
             "enteredbycode",
             "enteredbycodestd",
             "enteredbydesc",
             self.xml.entered_by,
-            optional=False,
+            optional=True,
         )
         self.add_code(
             "enteredatcode",
             "enteredatcodestd",
             "enteredatdesc",
             self.xml.entered_at,
-            optional=False,
+            optional=True,
         )
 
-        self.add_attributes()
+        # add former attributes
+        self.add_item("qhd19", self.xml.symtomatic_hypotension, optional=True)
+        self.add_item("qhd20", self.xml.vascular_access.code, optional=True)
+        self.add_item("qhd21", self.xml.vascular_access_site.code, optional=True)
+        self.add_item("qhd31", self.xml.time_dialysed, optional=True)
 
     def transformer(self):
         pass
@@ -790,28 +844,25 @@ class VascularAccess(Node):
             "proceduretypecodestd",
             "proceduretypedesc",
             self.xml.procedure_type,
+            optional=False,
         )
-        self.add_code(
-            "cliniciancode",
-            "cliniciancodestd",
-            "cliniciandesc",
-            self.xml.clinician,
-        )
-        self.add_item("proceduretime", self.xml.procedure_time)
+        self.add_item("proceduretime", self.xml.procedure_time, optional=False)
         self.add_code(
             "enteredbycode",
             "enteredbycodestd",
             "enteredbydesc",
             self.xml.entered_by,
+            optional=True,
         )
         self.add_code(
             "enteredatcode",
             "enteredatcodestd",
             "enteredatdesc",
             self.xml.entered_at,
+            optional=True,
         )
-        self.add_item("updatedon", self.xml.updated_on)
-        self.add_item("externalid", self.xml.external_id)
+        self.add_item("updatedon", self.xml.updated_on, optional=True)
+        self.add_item("externalid", self.xml.external_id, optional=True)
         self.add_acc()
 
     def transformer(self):
@@ -823,31 +874,48 @@ class Document(Node):
         super().__init__(xml, sqla.Document)
 
     def map_xml_to_tree(self):
-        self.add_item("documenttime", self.xml.document_time)
-        self.add_item("notetext", self.xml.note_text)
+        self.add_item("documenttime", self.xml.document_time, optional=False)
+        self.add_item("notetext", self.xml.note_text, optional=True)
         self.add_code(
             "documenttypecode",
             "documenttypecodestd",
             "documenttypedesc",
             self.xml.document_type,
+            optional=True,
         )
         self.add_code(
-            "cliniciancode", "cliniciancodestd", "cliniciandesc", self.xml.clinician
+            "cliniciancode",
+            "cliniciancodestd",
+            "cliniciandesc",
+            self.xml.clinician,
+            optional=True,
         )
-        self.add_item("documentname", self.xml.document_name)
-        self.add_code("statuscode", "statuscodestd", "statusdesc", self.xml.status)
+        self.add_item("documentname", self.xml.document_name, optional=True)
         self.add_code(
-            "enteredbycode", "enteredbycodestd", "enteredbydesc", self.xml.entered_by
+            "statuscode", "statuscodestd", "statusdesc", self.xml.status, optional=True
         )
         self.add_code(
-            "enteredatcode", "enteredatcodestd", "enteredatdesc", self.xml.entered_at
+            "enteredbycode",
+            "enteredbycodestd",
+            "enteredbydesc",
+            self.xml.entered_by,
+            optional=True,
         )
-        self.add_item("filetype", self.xml.file_type)
-        self.add_item("filename", self.xml.file_name)
-        self.add_item("stream", self.xml.stream)
-        self.add_item("documenturl", self.xml.document_url)
-        self.add_item("updatedon", self.xml.updated_on)
-        self.add_item("externalid", self.xml.external_id)
+        self.add_code(
+            "enteredatcode",
+            "enteredatcodestd",
+            "enteredatdesc",
+            self.xml.entered_at,
+            optional=True,
+        )
+        self.add_item("filetype", self.xml.file_type, optional=True)
+        self.add_item("filename", self.xml.file_name, optional=True)
+        self.add_item("stream", self.xml.stream, optional=True)
+        self.add_item("documenturl", self.xml.document_url, optional=True)
+
+        # common metadata
+        self.add_item("updatedon", self.xml.updated_on, optional=True)
+        self.add_item("externalid", self.xml.external_id, optional=True)
 
     def transformer(self):
         pass
@@ -858,16 +926,17 @@ class Encounter(Node):
         super().__init__(xml, sqla.Encounter)
 
     def map_xml_to_tree(self):
-        self.add_item("encounternumber", self.xml.encounter_number)
-        self.add_item("encountertype", self.xml.encounter_type)
-        self.add_item("fromtime", self.xml.from_time)
-        self.add_item("totime", self.xml.to_time)
+        self.add_item("encounternumber", self.xml.encounter_number, optional=True)
+        self.add_item("encountertype", self.xml.encounter_type, optional=False)
+        self.add_item("fromtime", self.xml.from_time, optional=False)
+        self.add_item("totime", self.xml.to_time, optional=True)
 
         self.add_code(
             "admittingcliniciancode",
             "admittingcliniciancodestd",
             "admittingcliniciandesc",
             self.xml.admitting_clinician,
+            optional=True,
         )
 
         self.add_code(
@@ -875,6 +944,7 @@ class Encounter(Node):
             "healthcarefacilitycodestd",
             "healthcarefacilitydesc",
             self.xml.health_care_facility,
+            optional=True,
         )
 
         self.add_code(
@@ -882,10 +952,44 @@ class Encounter(Node):
             "admitreasoncodestd",
             "admitreasondesc",
             self.xml.admit_reason,
+            optional=True,
         )
 
-        self.add_item("updatedon", self.xml.updated_on)
-        self.add_item("externalid", self.xml.external_id)
+        self.add_code(
+            "admissionsourcecode",
+            "admissionsourcecodestd",
+            "admissionsourcedesc",
+            self.xml.admission_source,
+            optional=True,
+        )
+
+        self.add_code(
+            "dischargereasoncode",
+            "dischargereasoncodestd",
+            "dischargereasondesc",
+            self.xml.discharge_reason,
+            optional=True,
+        )
+
+        self.add_code(
+            "dischargelocationcode",
+            "dischargelocationcodestd",
+            "dischargelocationdesc",
+            self.xml.discharge_location,
+            optional=True,
+        )
+
+        self.add_code(
+            "enteredatcode",
+            "enteredatcodestd",
+            "enteredatdesc",
+            self.xml.entered_at,
+            optional=True,
+        )
+
+        self.add_item("visitdescription", self.xml.visit_description, optional=True)
+        self.add_item("updatedon", self.xml.updated_on, optional=True)
+        self.add_item("externalid", self.xml.external_id, optional=True)
 
     def transformer(self):
         pass
@@ -896,63 +1000,67 @@ class Treatment(Node):
         super().__init__(xml, sqla.Treatment)
 
     def map_xml_to_tree(self):
-        self.add_item("encounternumber", self.xml.encounter_number)
-        self.add_item("encountertype", self.xml.encounter_type)
-        self.add_item("fromtime", self.xml.from_time)
-        self.add_item("totime", self.xml.to_time)
+        self.add_item("encounternumber", self.xml.encounter_number, optional=True)
+        self.add_item("fromtime", self.xml.from_time, optional=False)
+        self.add_item("totime", self.xml.to_time, optional=True)
         self.add_code(
             "admittingcliniciancode",
             "admittingcliniciancodestd",
             "admittingcliniciandesc",
             self.xml.admitting_clinician,
-        )
-        self.add_code(
-            "admitreasoncode",
-            "admitreasoncodestd",
-            "admitreasondesc",
-            self.xml.admit_reason,
-        )
-        self.add_code(
-            "admissionsourcecode",
-            "admissionsourcecodestd",
-            "admissionsourcedesc",
-            self.xml.admission_source,
-        )
-        self.add_code(
-            "dischargereasoncode",
-            "dischargereasoncodestd",
-            "dischargereasondesc",
-            self.xml.discharge_reason,
-        )
-        self.add_code(
-            "dischargelocationcode",
-            "dischargelocationcodestd",
-            "dischargelocationdesc",
-            self.xml.discharge_location,
+            optional=True,
         )
         self.add_code(
             "healthcarefacilitycode",
             "healthcarefacilitycodestd",
             "healthcarefacilitydesc",
             self.xml.health_care_facility,
+            optional=True,
         )
+        self.add_code(
+            "admitreasoncode",
+            "admitreasoncodestd",
+            "admitreasondesc",
+            self.xml.admit_reason,
+            optional=True,
+        )
+
+        self.add_code(
+            "admissionsourcecode",
+            "admissionsourcecodestd",
+            "admissionsourcedesc",
+            self.xml.admission_source,
+            optional=True,
+        )
+        self.add_code(
+            "dischargereasoncode",
+            "dischargereasoncodestd",
+            "dischargereasondesc",
+            self.xml.discharge_reason,
+            optional=True,
+        )
+        self.add_code(
+            "dischargelocationcode",
+            "dischargelocationcodestd",
+            "dischargelocationdesc",
+            self.xml.discharge_location,
+            optional=True,
+        )
+
         self.add_code(
             "enteredatcode",
             "enteredatcodestd",
             "enteredatdesc",
             self.xml.entered_at,
+            optional=True,
         )
 
-        self.add_item("visitdescription", self.xml.visit_description)
-        self.add_item("hdp01", self.xml.attributes.hdp01)
-        self.add_item("hdp02", self.xml.attributes.hdp02)
-        self.add_item("hdp03", self.xml.attributes.hdp03)
-        self.add_item("hdp04", self.xml.attributes.hdp04)
-        self.add_item("qbl05", self.xml.attributes.qbl05)
-        self.add_item("qbl06", self.xml.attributes.qbl06)
-        self.add_item("qbl07", self.xml.attributes.qbl07)
-        self.add_item("erf61", self.xml.attributes.erf61)
-        self.add_item("pat35", self.xml.attributes.pat35)
+        self.add_item("visitdescription", self.xml.visit_description, optional=True)
+        self.add_item("qbl05", self.xml.attributes.qbl05, optional=True)
+
+        # common metadata
+        self.add_item("update_date", self.xml.updated_on, optional=True)
+        self.add_item("externalid", self.xml.external_id, optional=True)
 
     def transformer(self):
         pass
@@ -963,54 +1071,64 @@ class TransplantList(Node):
         super().__init__(xml, sqla.TransplantList)
 
     def map_xml_to_tree(self):
-        self.add_item("encounternumber", self.xml.encounter_number)
-        self.add_item("encountertype", self.xml.encounter_type)
-        self.add_item("fromtime", self.xml.from_time)
-        self.add_item("totime", self.xml.to_time)
+        self.add_item("encounternumber", self.xml.encounter_number, optional=False)
+        self.add_item("encountertype", self.xml.encounter_type, optional=True)
+        self.add_item("fromtime", self.xml.from_time, optional=False)
+        self.add_item("totime", self.xml.to_time, optional=True)
 
         self.add_code(
             "admittingcliniciancode",
             "admittingcliniciancodestd",
             "admittingcliniciandesc",
             self.xml.admitting_clinician,
+            optional=True,
         )
         self.add_code(
             "healthcarefacilitycode",
             "healthcarefacilitycodestd",
             "healthcarefacilitydesc",
             self.xml.health_care_facility,
+            optional=True,
         )
         self.add_code(
             "admitreasoncode",
             "admitreasoncodestd",
             "admitreasondesc",
             self.xml.admit_reason,
+            optional=True,
         )
         self.add_code(
             "admissionsourcecode",
             "admissionsourcecodestd",
             "admissionsourcedesc",
             self.xml.admission_source,
+            optional=True,
         )
         self.add_code(
             "dischargereasoncode",
             "dischargereasoncodestd",
             "dischargereasondesc",
             self.xml.discharge_reason,
+            optional=True,
         )
         self.add_code(
             "dischargelocationcode",
             "dischargelocationcodestd",
             "dischargelocationdesc",
             self.xml.discharge_location,
+            optional=True,
         )
         self.add_code(
-            "enteredatcode", "enteredatcodestd", "enteredatdesc", self.xml.entered_at
+            "enteredatcode",
+            "enteredatcodestd",
+            "enteredatdesc",
+            self.xml.entered_at,
+            optional=True,
         )
 
-        self.add_item("visitdescription", self.xml.visit_description)
-        self.add_item("updatedon", self.xml.updated_on)
-        self.add_item("externalid", self.xml.external_id)
+        self.add_item("visitdescription", self.xml.visit_description, optional=True)
+        self.add_item("updatedon", self.xml.updated_on, optional=True)
+        self.add_item("externalid", self.xml.external_id, optional=True)
 
     def transformer(self):
         pass
@@ -1026,19 +1144,21 @@ class ProgramMembership(Node):
             "enteredbycodestd",
             "enteredbycodedesc",
             self.xml.entered_by,
+            optional=True,
         )
         self.add_code(
             "enteredatcode",
             "enteredatcodestd",
             "enteredatcodedesc",
             self.xml.entered_at,
+            optional=True,
         )
-        self.add_item("programname", self.xml.program_name)
-        self.add_item("programdescription", self.xml.program_description)
-        self.add_item("fromtime", self.xml.from_time)
-        self.add_item("totime", self.xml.to_time)
-        self.add_item("updatedon", self.xml.updated_on)
-        self.add_item("externalid", self.xml.external_id)
+        self.add_item("programname", self.xml.program_name, optional=True)
+        self.add_item("programdescription", self.xml.program_description, optional=True)
+        self.add_item("fromtime", self.xml.from_time, optional=False)
+        self.add_item("totime", self.xml.to_time, optional=True)
+        self.add_item("updatedon", self.xml.updated_on, optional=True)
+        self.add_item("externalid", self.xml.external_id, optional=True)
 
     def transformer(self):
         pass
@@ -1049,24 +1169,28 @@ class OptOut(Node):
         super().__init__(xml, sqla.OptOut)
 
     def map_xml_to_tree(self):
-        self.add_item("program_name", self.xml.program_name)
-        self.add_item("program_description", self.xml.program_description)
+        self.add_item("program_name", self.xml.program_name, optional=False)
+        self.add_item(
+            "program_description", self.xml.program_description, optional=True
+        )
         self.add_code(
             "entered_by_code",
             "entered_by_code_std",
             "entered_by_desc",
             self.xml.entered_by,
+            optional=True,
         )
         self.add_code(
             "entered_at_code",
             "entered_at_code_std",
             "entered_at_desc",
             self.xml.entered_at,
+            optional=True,
         )
-        self.add_item("from_time", self.xml.from_time)
-        self.add_item("to_time", self.xml.to_time)
-        self.add_item("updated_on", self.xml.updated_on)
-        self.add_item("external_id", self.xml.external_id)
+        self.add_item("from_time", self.xml.from_time, optional=False)
+        self.add_item("to_time", self.xml.to_time, optional=True)
+        self.add_item("updated_on", self.xml.updated_on, optional=True)
+        self.add_item("external_id", self.xml.external_id, optional=True)
 
     def transformer(self):
         pass
@@ -1078,13 +1202,21 @@ class ClinicalRelationship(Node):
 
     def map_xml_to_tree(self):
         self.add_code(
-            "cliniciancode", "cliniciancodestd", "cliniciandesc", self.xml.clinician
+            "cliniciancode",
+            "cliniciancodestd",
+            "cliniciandesc",
+            self.xml.clinician,
+            optional=True,
         )
         self.add_code(
-            "facilitycode", "facilitycodestd", "facilitydesc", self.xml.facility_code
+            "facilitycode",
+            "facilitycodestd",
+            "facilitydesc",
+            self.xml.facility_code,
+            optional=True,
         )
         self.add_item("fromtime", self.xml.from_time, optional=False)
-        self.add_item("totime", self.xml.to_time, optional=False)
+        self.add_item("totime", self.xml.to_time, optional=True)
         self.add_item("updatedon", self.xml.updated_on)
         self.add_item("externalid", self.xml.external_id)
 
@@ -1103,35 +1235,29 @@ class Observation(Node):
             "observationcodestd",
             "observationdesc",
             self.xml.observation_code,
-            optional=False,
+            optional=True,
         )
-        self.add_item("observationvalue", self.xml.observation_value)
-        self.add_item("observationunits", self.xml.observation_units)
-        self.add_item("prepost", self.xml.pre_post)
-        self.add_item("commenttext", self.xml.comments)
-        self.add_code(
-            "cliniciancode",
-            "cliniciancodestd",
-            "cliniciandesc",
-            self.xml.clinician,
-            optional=False,
-        )
+        self.add_item("observationvalue", self.xml.observation_value, optional=True)
+        self.add_item("observationunits", self.xml.observation_units, optional=True)
+        self.add_item("prepost", self.xml.pre_post, optional=True)
+        self.add_item("commenttext", self.xml.comments, optional=True)
+
         self.add_code(
             "enteredatcode",
             "enteredatcodestd",
             "enteredatdesc",
             self.xml.entered_at,
-            optional=False,
+            optional=True,
         )
         self.add_code(
             "enteringorganizationcode",
             "enteringorganizationcodestd",
             "enteringorganizationdesc",
             self.xml.entering_organization,
-            optional=False,
+            optional=True,
         )
-        self.add_item("updatedon", self.xml.updated_on, optional=False)
-        self.add_item("externalid", self.xml.external_id, optional=False)
+        self.add_item("updatedon", self.xml.updated_on, optional=True)
+        self.add_item("externalid", self.xml.external_id, optional=True)
 
     def transformer(self):
         pass
@@ -1141,58 +1267,33 @@ class Transplant(Node):
     def __init__(self, xml: xsd_transplants.TransplantProcedure):
         super().__init__(xml, sqla.Transplant)
 
-    def add_attributes(self):
-        if self.xml.attributes:
-            self.add_item("tra64", self.xml.attributes.tra64)
-            self.add_item("tra65", self.xml.attributes.tra65)
-            self.add_item("tra66", self.xml.attributes.tra66)
-            self.add_item("tra69", self.xml.attributes.tra69)
-            self.add_item("tra76", self.xml.attributes.tra76)
-            self.add_item("tra77", self.xml.attributes.tra77)
-            self.add_item("tra78", self.xml.attributes.tra78)
-            self.add_item("tra79", self.xml.attributes.tra79)
-            self.add_item("tra80", self.xml.attributes.tra80)
-            self.add_item("tra8a", self.xml.attributes.tra8_a)
-            self.add_item("tra81", self.xml.attributes.tra81)
-            self.add_item("tra82", self.xml.attributes.tra82)
-            self.add_item("tra83", self.xml.attributes.tra83)
-            self.add_item("tra84", self.xml.attributes.tra84)
-            self.add_item("tra85", self.xml.attributes.tra85)
-            self.add_item("tra86", self.xml.attributes.tra86)
-            self.add_item("tra87", self.xml.attributes.tra87)
-            self.add_item("tra88", self.xml.attributes.tra88)
-            self.add_item("tra89", self.xml.attributes.tra89)
-            self.add_item("tra90", self.xml.attributes.tra90)
-            self.add_item("tra91", self.xml.attributes.tra91)
-            self.add_item("tra92", self.xml.attributes.tra92)
-            self.add_item("tra93", self.xml.attributes.tra93)
-            self.add_item("tra94", self.xml.attributes.tra94)
-            self.add_item("tra95", self.xml.attributes.tra95)
-            self.add_item("tra96", self.xml.attributes.tra96)
-            self.add_item("tra97", self.xml.attributes.tra97)
-            self.add_item("tra98", self.xml.attributes.tra98)
-
     def map_xml_to_tree(self):
         self.add_code(
             "proceduretypecode",
             "proceduretypecodestd",
             "proceduretypedesc",
             self.xml.procedure_type,
+            optional=False,
         )
-        self.add_code(
-            "cliniciancode", "cliniciancodestd", "cliniciandesc", self.xml.clinician
-        )
-        self.add_item("proceduretime", self.xml.procedure_time)
+        self.add_item("proceduretime", self.xml.procedure_time, optional=False)
         self.add_code(
             "enteredbycode", "enteredbycodestd", "enteredbydesc", self.xml.entered_by
         )
         self.add_code(
             "enteredatcode", "enteredatcodestd", "enteredatdesc", self.xml.entered_at
         )
-        self.add_item("updatedon", self.xml.updated_on)
-        self.add_item("externalid", self.xml.external_id)
 
-        self.add_attributes()
+        self.add_item("updatedon", self.xml.updated_on, optional=True)
+        self.add_item("externalid", self.xml.external_id, optional=True)
+
+        # former attributes
+        self.add_item("tra77", self.xml.donor_type)
+        self.add_item("tra72", self.xml.date_registered)
+        self.add_item("tra64", self.xml.failure_date)
+        self.add_item("tra91", self.xml.cold_ischaemic_time)
+        self.add_item("tra83", self.xml.hlamismatch_a)
+        self.add_item("tra84", self.xml.hlamismatch_b)
+        self.add_item("tra85", self.xml.hlamismatch_c)
 
     def transformer(self):
         return

--- a/src/ukrdc_cupid/core/store/models/ukrdc.py
+++ b/src/ukrdc_cupid/core/store/models/ukrdc.py
@@ -622,6 +622,8 @@ class RenalDiagnosis(Node):
         self.add_item("onsettime", self.xml.onset_time)
         self.add_item("enteredon", self.xml.entered_on)
 
+        # biopsyperformed and verification status will need to be added when the database supports them
+
     def transformer(self):
         pass
 

--- a/tests/test_store_ukrdc.py
+++ b/tests/test_store_ukrdc.py
@@ -631,14 +631,16 @@ def test_cause_of_death():
 
 
 def test_renal_diagnosis():
-    diagnosis_type = "Type B"
+    diagnosis_type = "PRIMARY"
     diagnosing_clinician_coding_standard = "LOCAL"
     diagnosing_clinician_code = "54321"
     diagnosis_coding_standard = "EDTA2"
     diagnosis_code = "42"
+    biopsy_performed = "Y"
     comments = "This is another comment."
     identification_time = dt.datetime(2023, 6, 1)
     onset_time = dt.datetime(2023, 5, 30)
+    verification_status = "confirmed"
     entered_on = dt.datetime(2023, 5, 31)
 
     xml = XmlParser().from_string(
@@ -652,9 +654,11 @@ def test_renal_diagnosis():
                     <CodingStandard>{diagnosis_coding_standard}</CodingStandard>
                     <Code>{diagnosis_code}</Code>
                 </Diagnosis>
+                <BiopsyPerformed>{biopsy_performed}</BiopsyPerformed>
                 <Comments>{comments}</Comments>
                 <IdentificationTime>{XmlDateTime.from_datetime(identification_time)}</IdentificationTime>
                 <OnsetTime>{XmlDateTime.from_datetime(onset_time)}</OnsetTime>
+                <VerificationStatus>{verification_status}</VerificationStatus>
                 <EnteredOn>{XmlDateTime.from_datetime(entered_on)}</EnteredOn>
             </RenalDiagnosis>""",
         xsd_diagnosis.RenalDiagnosis
@@ -672,9 +676,11 @@ def test_renal_diagnosis():
     assert renal_diagnosis.orm_object.diagnosingcliniciancode == diagnosing_clinician_code
     assert renal_diagnosis.orm_object.diagnosiscodestd == diagnosis_coding_standard
     assert renal_diagnosis.orm_object.diagnosiscode == diagnosis_code
+    #assert renal_diagnosis.orm_object.biopsyperformed == biopsy_performed
     assert renal_diagnosis.orm_object.comments == comments
     assert renal_diagnosis.orm_object.identificationtime == identification_time
     assert renal_diagnosis.orm_object.onsettime == onset_time
+    #assert renal_diagnosis.orm_object.verificationstatus == verification_status
     assert renal_diagnosis.orm_object.enteredon == entered_on
 
 

--- a/tests/test_store_ukrdc.py
+++ b/tests/test_store_ukrdc.py
@@ -38,7 +38,7 @@ def test_patient_record_xml_mapping():
     """
     To be expanded: this test loads a full xml record 
     """
-    xml = load_xml_from_path(r"scripts/xml_examples/UKRDC_v3.xml")
+    xml = load_xml_from_path(r"tests/xml_files/UKRDC_v4_0_0.xml")
 
     patient_record = models.PatientRecord(xml)
     patient_record.map_xml_to_tree()
@@ -535,6 +535,7 @@ def test_diagnosis():
     entered_at_coding_standard = "LOCAL"
     entered_at_code = "Hospital123"
     entered_at_description = "Hospital"
+    biopsy_performed = "Y"
 
     xml = XmlParser().from_string(
         f"""<Diagnosis>
@@ -549,17 +550,13 @@ def test_diagnosis():
                     <Code>{diagnosis_code}</Code>
                     <Description>{diagnosis_description}</Description>
                 </Diagnosis>
+                <BiopsyPerformed>{biopsy_performed}</BiopsyPerformed>
                 <Comments>{comments}</Comments>
                 <IdentificationTime>{XmlDateTime.from_datetime(identification_time)}</IdentificationTime>
                 <OnsetTime>{XmlDateTime.from_datetime(onset_time)}</OnsetTime>
                 <VerificationStatus>{verification_status}</VerificationStatus>
                 <EnteredOn>{XmlDateTime.from_datetime(entered_on)}</EnteredOn>
                 <EncounterNumber>{encounter_number}</EncounterNumber>
-                <EnteredAt>
-                    <CodingStandard>{entered_at_coding_standard}</CodingStandard>
-                    <Code>{entered_at_code}</Code>
-                    <Description>{entered_at_description}</Description>
-                </EnteredAt>
             </Diagnosis>""",
         xsd_diagnosis.Diagnosis
     )
@@ -584,33 +581,33 @@ def test_diagnosis():
     assert diagnosis.orm_object.verificationstatus == verification_status
     assert diagnosis.orm_object.enteredon == entered_on
     assert diagnosis.orm_object.encounternumber == encounter_number
-    assert diagnosis.orm_object.enteredatcode == entered_at_code
-    assert diagnosis.orm_object.enteredatcodestd == entered_at_coding_standard
 
 
 def test_cause_of_death():
-    diagnosis_type = "Type A"
-    diagnosing_clinician_coding_standard = "LOCAL"
-    diagnosing_clinician_code = "12345"
+    diagnosis_type = "PRIMARY"
     diagnosis_coding_standard = "EDTA_COD"
     diagnosis_code = "38"
+    diagnosis_code_desc = "Generalised Viral Infection"
     comments = "This is a comment."
     entered_on = dt.datetime(2023,5,31)
+    updated_on = dt.datetime(2023, 6, 10)
+    external_id = "ABC123"
+    verification_status = "provisional"
 
     xml = XmlParser().from_string(
         f"""<CauseOfDeath>
                 <DiagnosisType>{diagnosis_type}</DiagnosisType>
-                <DiagnosingClinician>
-                    <CodingStandard>{diagnosing_clinician_coding_standard}</CodingStandard>
-                    <Code>{diagnosing_clinician_code}</Code>
-                </DiagnosingClinician>
                 <Diagnosis>
                     <CodingStandard>{diagnosis_coding_standard}</CodingStandard>
                     <Code>{diagnosis_code}</Code>
+                    <Description>{diagnosis_code_desc}</Description>
                 </Diagnosis>
                 <Comments>{comments}</Comments>
+                <VerificationStatus>{verification_status}</VerificationStatus>
                 <EnteredOn>{XmlDateTime.from_datetime(entered_on)}</EnteredOn>
-            </CauseOfDeath>""",
+                <UpdatedOn>{XmlDateTime.from_datetime(updated_on)}</UpdatedOn>
+                <ExternalId>{external_id}</ExternalId>
+        </CauseOfDeath>""",
         xsd_diagnosis.CauseOfDeath
     )
 
@@ -621,13 +618,13 @@ def test_cause_of_death():
 
     # check values
     cause_of_death.map_xml_to_tree()
-    assert cause_of_death.orm_object.diagnosistype == diagnosis_type
-    assert cause_of_death.orm_object.diagnosingcliniciancodestd == diagnosing_clinician_coding_standard
-    assert cause_of_death.orm_object.diagnosingcliniciancode == diagnosing_clinician_code
     assert cause_of_death.orm_object.diagnosiscodestd == diagnosis_coding_standard
     assert cause_of_death.orm_object.diagnosiscode == diagnosis_code
+    assert cause_of_death.orm_object.diagnosisdesc == diagnosis_code_desc
     assert cause_of_death.orm_object.comments == comments
     assert cause_of_death.orm_object.enteredon == entered_on
+    assert cause_of_death.orm_object.externalid == external_id
+    assert cause_of_death.orm_object.updatedon == updated_on
 
 
 def test_renal_diagnosis():
@@ -688,18 +685,21 @@ def test_medication():
     prescription_number = "123456789"
     from_time = dt.datetime(2006, 5, 4, 18, 13, 51)
     to_time = dt.datetime(2006, 5, 4, 18, 13, 51)
-    ordered_by_code = "1234"
-    ordered_by_desc = "Dr. Robert"
     entering_organization_code = "RFDOG"
     entering_organization_desc = "whoof"
+    entering_organization_code_std = "LOCAL"
+
     route_code = "1"
     route_desc = "Oral"
+    route_code_std = "RR22"
     drug_product_generic = "Generic0"
     drug_product_label_name = "LabelName0"
     drug_product_form_code = "Code60"
     drug_product_form_desc = "Description60"
     drug_product_strength_units_code = "l"
     drug_product_strength_units_desc = "Description61"
+    drug_product_strength_code_std =  "CF_RR23"
+    drug_product_coding_std = "SNOMED"
     frequency = "Frequency0"
     comments = "Comments17"
     dose_quantity = 0
@@ -713,18 +713,13 @@ def test_medication():
                 <PrescriptionNumber>{prescription_number}</PrescriptionNumber>
                 <FromTime>{XmlDateTime.from_datetime(from_time)}</FromTime>
                 <ToTime>{XmlDateTime.from_datetime(to_time)}</ToTime>
-                <OrderedBy>
-                    <CodingStandard>LOCAL</CodingStandard>
-                    <Code>{ordered_by_code}</Code>
-                    <Description>{ordered_by_desc}</Description>
-                </OrderedBy>
                 <EnteringOrganization>
-                    <CodingStandard>ODS</CodingStandard>
+                    <CodingStandard>{entering_organization_code_std}</CodingStandard>
                     <Code>{entering_organization_code}</Code>
                     <Description>{entering_organization_desc}</Description>
                 </EnteringOrganization>
                 <Route>
-                    <CodingStandard>RR22</CodingStandard>
+                    <CodingStandard>{route_code_std}</CodingStandard>
                     <Code>{route_code}</Code>
                     <Description>{route_desc}</Description>
                 </Route>
@@ -732,12 +727,12 @@ def test_medication():
                     <Generic>{drug_product_generic}</Generic>
                     <LabelName>{drug_product_label_name}</LabelName>
                     <Form>
-                        <CodingStandard>SNOMED</CodingStandard>
+                        <CodingStandard>{drug_product_coding_std}</CodingStandard>
                         <Code>{drug_product_form_code}</Code>
                         <Description>{drug_product_form_desc}</Description>
                     </Form>
                     <StrengthUnits>
-                        <CodingStandard>CF_RR23</CodingStandard>
+                        <CodingStandard>{drug_product_strength_code_std}</CodingStandard>
                         <Code>{drug_product_strength_units_code}</Code>
                         <Description>{drug_product_strength_units_desc}</Description>
                     </StrengthUnits>
@@ -766,12 +761,12 @@ def test_medication():
     assert medication.orm_object.prescriptionnumber == prescription_number
     assert medication.orm_object.fromtime == from_time
     assert medication.orm_object.totime == to_time
-    assert medication.orm_object.orderedbycode == ordered_by_code
-    assert medication.orm_object.orderedbydesc == ordered_by_desc
     assert medication.orm_object.enteringorganizationcode == entering_organization_code
     assert medication.orm_object.enteringorganizationdesc == entering_organization_desc
+    assert medication.orm_object.enteringorganizationcodestd == entering_organization_code_std
     assert medication.orm_object.routecode == route_code
     assert medication.orm_object.routedesc == route_desc
+    assert medication.orm_object.routecodestd == route_code_std
     assert medication.orm_object.drugproductgeneric == drug_product_generic
     assert medication.orm_object.drugproductlabelname == drug_product_label_name
     assert medication.orm_object.drugproductformcode == drug_product_form_code
@@ -783,7 +778,12 @@ def test_medication():
     assert (
         medication.orm_object.drugproductstrengthunitsdesc
         == drug_product_strength_units_desc
+    )    
+    assert (
+        medication.orm_object.drugproductstrengthunitscodestd
+        == drug_product_strength_code_std
     )
+    assert medication.orm_object
     assert medication.orm_object.frequency == frequency
     assert medication.orm_object.commenttext == comments
     assert medication.orm_object.dosequantity == dose_quantity
@@ -796,18 +796,17 @@ def test_medication():
 def test_procedure():
 
     procedure_type_code = "Type B"
-    procedure_type_code_std = "ODS"
+    procedure_type_code_std = "SNOMED"
     procedure_type_desc = "queso con aceitunas"
-    clinician_code = "54321"
-    clinician_code_std = "LOCAL"
-    clinician_code_desc = "Dr Dolittle"
     procedure_time = dt.datetime(2023, 6, 1)
     entered_by_code = "12345"
     entered_by_code_std = "ODS"
-    entered_by_desc = "sdf;askdf "
-    entered_at_code = "RXF01"
+    entered_by_desc = "Dr Who"
+    entered_at_code = "RFCAT"
     entered_at_code_std = "LOCAL"
-    entered_at_code_desc = "sadfsad "
+    entered_at_code_desc = "Meow"
+    external_id = "ExternalId15"
+    from_time = dt.datetime(2023, 7, 1)
 
     xml = XmlParser().from_string( 
         f"""<Procedure>
@@ -816,11 +815,6 @@ def test_procedure():
                     <Code>{procedure_type_code}</Code>
                     <Description>{procedure_type_desc}</Description>
                 </ProcedureType>
-                <Clinician>
-                    <CodingStandard>{clinician_code_std}</CodingStandard>
-                    <Code>{clinician_code}</Code>
-                    <Description>{clinician_code_desc}</Description>
-                </Clinician>
                 <ProcedureTime>{XmlDateTime.from_datetime(procedure_time)}</ProcedureTime>
                 <EnteredBy>
                     <CodingStandard>{entered_by_code_std}</CodingStandard>
@@ -832,6 +826,8 @@ def test_procedure():
                     <Code>{entered_at_code}</Code>
                     <Description>{entered_at_code_desc}</Description>
                 </EnteredAt>
+                <UpdatedOn>{XmlDateTime.from_datetime(from_time)}</UpdatedOn>
+                <ExternalId>{external_id}</ExternalId>
             </Procedure>""",
             xsd_procedures.Procedure
     )
@@ -846,9 +842,6 @@ def test_procedure():
     assert procedure.orm_object.proceduretypecode == procedure_type_code
     assert procedure.orm_object.proceduretypecodestd == procedure_type_code_std
     assert procedure.orm_object.proceduretypedesc == procedure_type_desc
-    assert procedure.orm_object.cliniciancode == clinician_code
-    assert procedure.orm_object.cliniciancodestd == clinician_code_std
-    assert procedure.orm_object.cliniciandesc == clinician_code_desc
     assert procedure.orm_object.proceduretime == procedure_time
     assert procedure.orm_object.enteredbycode == entered_by_code
     assert procedure.orm_object.enteredbycodestd == entered_by_code_std
@@ -856,15 +849,14 @@ def test_procedure():
     assert procedure.orm_object.enteredatcode == entered_at_code
     assert procedure.orm_object.enteredatcodestd == entered_at_code_std
     assert procedure.orm_object.enteredatdesc == entered_at_code_desc
+    assert procedure.orm_object.updatedon == from_time
+    assert procedure.orm_object.externalid == external_id
 
 def test_dialysis_session():
     # Define the dialysis session details
     procedure_type_code = "302497006"
     procedure_type_code_std = "SNOMED"
     procedure_type_desc = "Haemodialysis"
-    clinician_code = "54321"
-    clinician_code_std = "LOCAL"
-    clinician_code_desc = "Dr Dolittle"
     procedure_time = dt.datetime(2023, 6, 1)
     entered_by_code = "ABC123"
     entered_by_code_std = "ODS"
@@ -889,11 +881,6 @@ def test_dialysis_session():
                     <Code>{procedure_type_code}</Code>
                     <Description>{procedure_type_desc}</Description>
                 </ProcedureType>
-                <Clinician>
-                    <CodingStandard>{clinician_code_std}</CodingStandard>
-                    <Code>{clinician_code}</Code>
-                    <Description>{clinician_code_desc}</Description>
-                </Clinician>
                 <ProcedureTime>{XmlDateTime.from_datetime(procedure_time)}</ProcedureTime>
                 <EnteredBy>
                     <CodingStandard>{entered_by_code_std}</CodingStandard>
@@ -905,19 +892,19 @@ def test_dialysis_session():
                     <Code>{entered_at_code}</Code>
                     <Description>{entered_at_code_desc}</Description>
                 </EnteredAt>
-                <Attributes>
-                    <QHD19>{qhd19}</QHD19>
-                    <QHD20>{qhd20}</QHD20>
-                    <QHD21>{qhd21}</QHD21>
-                    <QHD22>{qhd22}</QHD22>
-                    <QHD30>{qhd30}</QHD30>
-                    <QHD31>{qhd31}</QHD31>
-                    <QHD32>{qhd32}</QHD32>
-                    <QHD33>{qhd33}</QHD33>
-                </Attributes>
+                <SymtomaticHypotension>{qhd19}</SymtomaticHypotension>
+                <VascularAccess>
+                    <Code>{qhd20}</Code>
+                </VascularAccess>
+                <VascularAccessSite>
+                    <Code>{qhd21}</Code>
+                </VascularAccessSite>
+                <TimeDialysed>{qhd31}</TimeDialysed>
             </DialysisSession>""",
         xsd_dialysis_session.DialysisSession
     )
+
+
 
     # Set up model
     dialysis_session = models.DialysisSession(xml)
@@ -929,9 +916,6 @@ def test_dialysis_session():
     assert dialysis_session.orm_object.proceduretypecode == procedure_type_code
     assert dialysis_session.orm_object.proceduretypecodestd == procedure_type_code_std
     assert dialysis_session.orm_object.proceduretypedesc == procedure_type_desc
-    assert dialysis_session.orm_object.cliniciancode == clinician_code
-    assert dialysis_session.orm_object.cliniciancodestd == clinician_code_std
-    assert dialysis_session.orm_object.cliniciandesc == clinician_code_desc
     assert dialysis_session.orm_object.proceduretime == procedure_time
     assert dialysis_session.orm_object.enteredbycode == entered_by_code
     assert dialysis_session.orm_object.enteredbycodestd == entered_by_code_std
@@ -942,20 +926,13 @@ def test_dialysis_session():
     assert dialysis_session.orm_object.qhd19 == qhd19
     assert dialysis_session.orm_object.qhd20 == qhd20
     assert dialysis_session.orm_object.qhd21 == qhd21
-    assert dialysis_session.orm_object.qhd22 == qhd22
-    assert dialysis_session.orm_object.qhd30 == qhd30
     assert dialysis_session.orm_object.qhd31 == qhd31
-    assert dialysis_session.orm_object.qhd32 == qhd32
-    assert dialysis_session.orm_object.qhd33 == qhd33
 
 def test_vascular_access():
     # Define the vascular access details
     procedure_type_code = "12345678"
     procedure_type_code_std = "SNOMED"
     procedure_type_desc = "Vascular Access Procedure"
-    clinician_code = "CL001"
-    clinician_code_std = "LOCAL"
-    clinician_code_desc = "Dr. Smith"
     procedure_time = dt.datetime(2023, 5, 30, 10, 15, 0)
     entered_by_code = "EN001"
     entered_by_code_std = "ODS"
@@ -980,11 +957,6 @@ def test_vascular_access():
                     <Code>{procedure_type_code}</Code>
                     <Description>{procedure_type_desc}</Description>
                 </ProcedureType>
-                <Clinician>
-                    <CodingStandard>{clinician_code_std}</CodingStandard>
-                    <Code>{clinician_code}</Code>
-                    <Description>{clinician_code_desc}</Description>
-                </Clinician>
                 <ProcedureTime>{XmlDateTime.from_datetime(procedure_time)}</ProcedureTime>
                 <EnteredBy>
                     <CodingStandard>{entered_by_code_std}</CodingStandard>
@@ -1020,9 +992,6 @@ def test_vascular_access():
     assert vascular_access.orm_object.proceduretypecode == procedure_type_code
     assert vascular_access.orm_object.proceduretypecodestd == procedure_type_code_std
     assert vascular_access.orm_object.proceduretypedesc == procedure_type_desc
-    assert vascular_access.orm_object.cliniciancode == clinician_code
-    assert vascular_access.orm_object.cliniciancodestd == clinician_code_std
-    assert vascular_access.orm_object.cliniciandesc == clinician_code_desc
     assert vascular_access.orm_object.proceduretime == procedure_time
     assert vascular_access.orm_object.enteredbycode == entered_by_code
     assert vascular_access.orm_object.enteredbycodestd == entered_by_code_std
@@ -1242,7 +1211,7 @@ def test_treatment():
     hdp02 = 180
     hdp03 = 400
     hdp04 = 140
-    qbl05 = "HOSP"
+    qbl05 = "INCENTRE"
     qbl06 = "Shared Care Example"
     qbl07 = "Y"
     erf61 = "3"
@@ -1251,7 +1220,6 @@ def test_treatment():
     xml = XmlParser().from_string(
         f'''<Treatment>
                 <EncounterNumber>{encounter_number}</EncounterNumber>
-                <EncounterType>{encounter_type}</EncounterType>
                 <FromTime>{XmlDateTime.from_datetime(from_time)}</FromTime>
                 <ToTime>{XmlDateTime.from_datetime(to_time)}</ToTime>
                 <AdmittingClinician>
@@ -1291,15 +1259,7 @@ def test_treatment():
                 </EnteredAt>
                 <VisitDescription>{visit_description}</VisitDescription>
                 <Attributes>
-                    <HDP01>{hdp01}</HDP01>
-                    <HDP02>{hdp02}</HDP02>
-                    <HDP03>{hdp03}</HDP03>
-                    <HDP04>{hdp04}</HDP04>
                     <QBL05>{qbl05}</QBL05>
-                    <QBL06>{qbl06}</QBL06>
-                    <QBL07>{qbl07}</QBL07>
-                    <ERF61>{erf61}</ERF61>
-                    <PAT35>{XmlDateTime.from_datetime(pat35)}</PAT35>
                 </Attributes>
             </Treatment>''',
             xsd_encounters.Treatment
@@ -1313,7 +1273,6 @@ def test_treatment():
     # assert orm_variables
     treatment.map_xml_to_tree()
     assert treatment.orm_object.encounternumber == encounter_number
-    assert treatment.orm_object.encountertype == encounter_type
     # TODO: fix these assert statements...not sure why they don't work
     #assert treatment.orm_object.fromtime == from_time
     #assert treatment.orm_object.totime == to_time
@@ -1339,16 +1298,9 @@ def test_treatment():
     assert treatment.orm_object.enteredatcodestd == entered_at_coding_standard
     assert treatment.orm_object.enteredatdesc == entered_at_description
     assert treatment.orm_object.visitdescription == visit_description
-    assert treatment.orm_object.hdp01 == hdp01
-    assert treatment.orm_object.hdp02 == hdp02
-    assert treatment.orm_object.hdp03 == hdp03
-    assert treatment.orm_object.hdp04 == hdp04
     assert treatment.orm_object.qbl05 == qbl05
-    assert treatment.orm_object.qbl06 == qbl06
-    assert treatment.orm_object.qbl07 == qbl07
-    assert treatment.orm_object.erf61 == erf61
-    assert treatment.orm_object.pat35 == pat35
 
+test_treatment()
 
 def test_transplant_list():
 
@@ -1686,11 +1638,6 @@ def test_observation():
                 <ObservationUnits>{observation_units}</ObservationUnits>
                 <PrePost>{pre_post}</PrePost>
                 <Comments>{comments}</Comments>
-                <Clinician>
-                    <CodingStandard>{clinician_coding_standard}</CodingStandard>
-                    <Code>{clinician_code}</Code>
-                    <Description>{clinician_description}</Description>
-                </Clinician>
                 <EnteredAt>
                     <CodingStandard>{entered_at_coding_standard}</CodingStandard>
                     <Code>{entered_at_code}</Code>
@@ -1720,9 +1667,6 @@ def test_observation():
     assert observation.orm_object.observationunits == observation_units
     assert observation.orm_object.prepost == pre_post
     assert observation.orm_object.commenttext == comments
-    assert observation.orm_object.cliniciancode == clinician_code
-    assert observation.orm_object.cliniciancodestd == clinician_coding_standard
-    assert observation.orm_object.cliniciandesc == clinician_description
     assert observation.orm_object.enteredatcode == entered_at_code
     assert observation.orm_object.enteredatcodestd == entered_at_coding_standard
     assert observation.orm_object.enteredatdesc == entered_at_description
@@ -1732,14 +1676,10 @@ def test_observation():
     #assert observation.orm_object.updatedon == updated_on
     assert observation.orm_object.externalid == external_id
 
-
 def test_transplant():
     procedure_type_code = "ProcedureTypeCode"
     procedure_type_code_std = "SNOMED"
     procedure_type_desc = "Procedure Type Description"
-    clinician_code = "ClinicianCode"
-    clinician_code_std = "LOCAL"
-    clinician_desc = "Clinician Description"
     procedure_time = dt.datetime(2023, 6, 12, 10, 0, 0)
     entered_by_code = "EnteredByCode"
     entered_by_code_std = "ODS"
@@ -1750,33 +1690,15 @@ def test_transplant():
     updated_on = dt.datetime(2023, 6, 13, 12, 0, 0)
     external_id = "ABC123"
     tra64 = dt.datetime(2023, 6, 10, 8, 0, 0)
-    tra65 = "10"
-    tra66 = "Failure description"
-    tra69 = dt.datetime(2023, 6, 10, 12, 0, 0)
-    tra76 = "Graft Type Description"
+
+    tra72 = dt.datetime(2023, 6, 10, 12, 0, 0)
+
     tra77 = "DBD"
-    tra78 = "POS"
-    tra79 = "NEG"
-    tra80 = 30
-    tra8a = "1"
-    tra81 = "UK"
-    tra82 = "POS"
     tra83 = "Mismatch A Value"
     tra84 = "Mismatch B Value"
     tra85 = "Mismatch DR Value"
-    tra86 = "Yes"
-    tra87 = "Yes"
-    tra88 = "Yes"
-    tra89 = "Yes"
-    tra90 = "Yes"
     tra91 = "5"
-    tra92 = "Yes"
-    tra93 = "Anticoagulation Value"
-    tra94 = "CMV prophylaxis Value"
-    tra95 = "Pneumocystis prophylaxis Value"
-    tra96 = "Yes"
-    tra97 = "11"
-    tra98 = "13"
+
 
     xml = XmlParser().from_string(
         f'''<TransplantProcedure>
@@ -1785,11 +1707,6 @@ def test_transplant():
                     <CodingStandard>{procedure_type_code_std}</CodingStandard>
                     <Description>{procedure_type_desc}</Description>
                 </ProcedureType>
-                <Clinician>
-                    <Code>{clinician_code}</Code>
-                    <CodingStandard>{clinician_code_std}</CodingStandard>
-                    <Description>{clinician_desc}</Description>
-                </Clinician>
                 <ProcedureTime>{XmlDate.from_datetime(procedure_time)}</ProcedureTime>
                 <EnteredBy>
                     <Code>{entered_by_code}</Code>
@@ -1803,36 +1720,13 @@ def test_transplant():
                 </EnteredAt>
                 <UpdatedOn>{XmlDate.from_datetime(updated_on)}</UpdatedOn>
                 <ExternalId>{external_id}</ExternalId>
-                <Attributes>
-                    <TRA64>{XmlDate.from_datetime(tra64)}</TRA64>
-                    <TRA65>{tra65}</TRA65>
-                    <TRA66>{tra66}</TRA66>
-                    <TRA69>{XmlDate.from_datetime(tra69)}</TRA69>
-                    <TRA76>{tra76}</TRA76>
-                    <TRA77>{tra77}</TRA77>
-                    <TRA78>{tra78}</TRA78>
-                    <TRA79>{tra79}</TRA79>
-                    <TRA80>{tra80}</TRA80>
-                    <TRA8A>{tra8a}</TRA8A>
-                    <TRA81>{tra81}</TRA81>
-                    <TRA82>{tra82}</TRA82>
-                    <TRA83>{tra83}</TRA83>
-                    <TRA84>{tra84}</TRA84>
-                    <TRA85>{tra85}</TRA85>
-                    <TRA86>{tra86}</TRA86>
-                    <TRA87>{tra87}</TRA87>
-                    <TRA88>{tra88}</TRA88>
-                    <TRA89>{tra89}</TRA89>
-                    <TRA90>{tra90}</TRA90>
-                    <TRA91>{tra91}</TRA91>
-                    <TRA92>{tra92}</TRA92>
-                    <TRA93>{tra93}</TRA93>
-                    <TRA94>{tra94}</TRA94>
-                    <TRA95>{tra95}</TRA95>
-                    <TRA96>{tra96}</TRA96>
-                    <TRA97>{tra97}</TRA97>
-                    <TRA98>{tra98}</TRA98>
-                </Attributes>
+                <DonorType>{tra77}</DonorType>
+                <DateRegistered>{tra72}</DateRegistered>
+                <FailureDate>{tra64}</FailureDate>
+                <ColdIschaemicTime>{tra91}</ColdIschaemicTime>
+                <HLAMismatchA>{tra83}</HLAMismatchA>
+                <HLAMismatchB>{tra84}</HLAMismatchB>
+                <HLAMismatchC>{tra85}</HLAMismatchC>
             </TransplantProcedure>''',
         xsd_transplants.TransplantProcedure
     )
@@ -1845,9 +1739,7 @@ def test_transplant():
     assert transplant.orm_object.proceduretypecode == procedure_type_code
     assert transplant.orm_object.proceduretypecodestd == procedure_type_code_std
     assert transplant.orm_object.proceduretypedesc == procedure_type_desc
-    assert transplant.orm_object.cliniciancode == clinician_code
-    assert transplant.orm_object.cliniciancodestd == clinician_code_std
-    assert transplant.orm_object.cliniciandesc == clinician_desc
+
     #assert transplant.orm_object.proceduretime == procedure_time
     assert transplant.orm_object.enteredbycode == entered_by_code
     assert transplant.orm_object.enteredbycodestd == entered_by_code_std
@@ -1857,34 +1749,11 @@ def test_transplant():
     assert transplant.orm_object.enteredatdesc == entered_at_desc
     #assert transplant.orm_object.updatedon == updated_on
     assert transplant.orm_object.externalid == external_id
-    #assert transplant.orm_object.tra64 == tra64
-    assert transplant.orm_object.tra65 == tra65
-    assert transplant.orm_object.tra66 == tra66
-    #assert transplant.orm_object.tra69 == tra69
-    assert transplant.orm_object.tra76 == tra76
     assert transplant.orm_object.tra77 == tra77
-    assert transplant.orm_object.tra78 == tra78
-    assert transplant.orm_object.tra79 == tra79
-    assert transplant.orm_object.tra80 == tra80
-    assert transplant.orm_object.tra8a == tra8a
-    assert transplant.orm_object.tra81 == tra81
-    assert transplant.orm_object.tra82 == tra82
     assert transplant.orm_object.tra83 == tra83
     assert transplant.orm_object.tra84 == tra84
     assert transplant.orm_object.tra85 == tra85
-    assert transplant.orm_object.tra86 == tra86
-    assert transplant.orm_object.tra87 == tra87
-    assert transplant.orm_object.tra88 == tra88
-    assert transplant.orm_object.tra89 == tra89
-    assert transplant.orm_object.tra90 == tra90
     assert transplant.orm_object.tra91 == tra91
-    assert transplant.orm_object.tra92 == tra92
-    assert transplant.orm_object.tra93 == tra93
-    assert transplant.orm_object.tra94 == tra94
-    assert transplant.orm_object.tra95 == tra95
-    assert transplant.orm_object.tra96 == tra96
-    assert transplant.orm_object.tra97 == tra97
-    assert transplant.orm_object.tra98 == tra98
 
 def test_level():
     pass

--- a/tests/xml_files/UKRDC_v4_0_0.xml
+++ b/tests/xml_files/UKRDC_v4_0_0.xml
@@ -1,0 +1,412 @@
+<ukrdc:PatientRecord xmlns:ukrdc="http://www.rixg.org.uk/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <SendingFacility channelName="UKRDCSampleExtract" schemaVersion="4.0.0" time="2023-08-16T08:32:40.306453">ABC123</SendingFacility>
+    <SendingExtract>UKRDC</SendingExtract>
+    <Patient>
+        <PatientNumbers>
+            <PatientNumber>
+                <Number>AAA111B</Number>
+                <Organization>LOCALHOSP</Organization>
+                <NumberType>MRN</NumberType>
+            </PatientNumber>
+            <PatientNumber>
+                <Number>1111111111</Number>
+                <Organization>NHS</Organization>
+                <NumberType>NI</NumberType>
+            </PatientNumber>
+        </PatientNumbers>
+        <Names>
+            <Name use="L">
+                <Prefix>Mr</Prefix>
+                <Family>Sample</Family>
+                <Given>John</Given>
+            </Name>
+        </Names>
+        <BirthTime>2006-05-04T18:13:51.0</BirthTime>
+        <Gender>1</Gender>
+        <Addresses>
+            <Address use="H">
+                <FromTime>2006-05-04</FromTime>
+                <ToTime>2006-05-04</ToTime>
+                <Street>Street0</Street>
+                <Town>Town0</Town>
+                <County>County0</County>
+                <Postcode>BS10 5NB</Postcode>
+                <Country>
+                    <CodingStandard>ISO3166-1</CodingStandard>
+                    <Code>GBR</Code>
+                    <Description>Great Britain</Description>
+                </Country>
+            </Address>
+        </Addresses>
+        <ContactDetails>
+            <ContactDetail use="PRN">
+                <Value>0117 11111111</Value>
+            </ContactDetail>
+        </ContactDetails>
+        <CountryOfBirth>GBR</CountryOfBirth>
+        <FamilyDoctor>
+            <GPPracticeId>J11111</GPPracticeId>
+            <GPId>G2222222</GPId>
+            <Email>reception@villagegp.nhs.uk</Email>
+        </FamilyDoctor>
+        <EthnicGroup>
+            <CodingStandard>NHS_DATA_DICTIONARY</CodingStandard>
+            <Code>A</Code>
+            <Description>White - British</Description>
+        </EthnicGroup>
+        <BloodGroup>A</BloodGroup>
+        <BloodRhesus>POS</BloodRhesus>
+        <Death>false</Death>
+        <UpdatedOn>2006-05-04T18:13:51.0</UpdatedOn>
+        <ExternalId>1122334455</ExternalId>
+    </Patient>
+
+    <LabOrders start="2021-01-01" stop="2021-04-01">
+        <LabOrder>
+            <ReceivingLocation>
+                <CodingStandard>RR1+</CodingStandard>
+                <Code>ABC123</Code>
+                <Description>Test Hospital</Description>
+            </ReceivingLocation>
+            <PlacerId>PlacerId0</PlacerId>
+            <FillerId>FillerId0</FillerId>
+            <OrderedBy>
+                <CodingStandard>ODS</CodingStandard>
+                <Code>AA1122</Code>
+                <Description>Test Hospital 2</Description>
+            </OrderedBy>
+            <OrderItem>
+                <CodingStandard>LOCAL</CodingStandard>
+                <Code>11223344</Code>
+                <Description>Full Blood Test</Description>
+            </OrderItem>
+            <SpecimenCollectedTime>2006-05-04T18:13:51.0</SpecimenCollectedTime>
+            <SpecimenReceivedTime>2006-05-04T18:13:51.0</SpecimenReceivedTime>
+            <SpecimenSource>BLOOD</SpecimenSource>
+
+            <ResultItems>
+                <ResultItem>
+                    <EnteredOn>2006-05-04T18:13:51.0</EnteredOn>
+                    <PrePost>PRE</PrePost>
+                    <ServiceId>
+                        <CodingStandard>UKRR</CodingStandard>
+                        <Code>QBLA1</Code>
+                        <Description>Serum Creatinine</Description>
+                    </ServiceId>
+                    <ResultValue>78</ResultValue>
+                    <ResultValueUnits>mmol/L</ResultValueUnits>
+                    <ReferenceRange>10-1000</ReferenceRange>
+                    <ObservationTime>2006-05-04T18:13:51.0</ObservationTime>
+                </ResultItem>
+                <ResultItem>
+                    <EnteredOn>2006-05-04T18:13:51.0</EnteredOn>
+                    <PrePost>PRE</PrePost>
+                    <ServiceId>
+                        <CodingStandard>UKRR</CodingStandard>
+                        <Code>QBLF7</Code>
+                        <Description>Serum B12</Description>
+                    </ServiceId>
+                    <ResultValue>100</ResultValue>
+                    <ResultValueUnits>ng/L</ResultValueUnits>
+                    <ReferenceRange>0-10000</ReferenceRange>
+                    <ObservationTime>2006-05-04T18:13:51.0</ObservationTime>
+                </ResultItem>
+            </ResultItems>
+
+            <EnteredOn>2006-05-04T18:13:51.0</EnteredOn>
+            <EnteredAt>
+                <CodingStandard>RR1+</CodingStandard>
+                <Code>ABC123</Code>
+                <Description>Test Hospital</Description>
+            </EnteredAt>
+            <EnteringOrganization>
+                <CodingStandard>RR1+</CodingStandard>
+                <Code>ABC123</Code>
+                <Description>Test Hospital</Description>
+            </EnteringOrganization>
+            <UpdatedOn>2006-05-04T18:13:51.0</UpdatedOn>
+            <ExternalId>9999999999</ExternalId>
+        </LabOrder>
+    </LabOrders>
+
+    <Observations start="2021-01-01" stop="2021-04-01">
+        <Observation>
+            <ObservationTime>2006-05-04T18:13:51.0</ObservationTime>
+            <ObservationCode>
+                <CodingStandard>UKRR</CodingStandard>
+                <Code>QBLG3</Code>
+                <Description>Systolic BP</Description>
+            </ObservationCode>
+            <ObservationValue>150</ObservationValue>
+            <ObservationUnits>mmHg</ObservationUnits>
+            <PrePost>PRE</PrePost>
+            <EnteredAt>
+                <CodingStandard>RR1+</CodingStandard>
+                <Code>ABC123</Code>
+                <Description>Test Hospital</Description>
+            </EnteredAt>
+            <EnteringOrganization>
+                <CodingStandard>RR1+</CodingStandard>
+                <Code>ABC123</Code>
+                <Description>Test Hospital</Description>
+            </EnteringOrganization>
+            <UpdatedOn>2006-05-04T18:13:51.0</UpdatedOn>
+            <ExternalId>88888888</ExternalId>
+        </Observation>
+        <Observation>
+            <ObservationTime>2006-05-04T18:13:51.0</ObservationTime>
+            <ObservationCode>
+                <CodingStandard>UKRR</CodingStandard>
+                <Code>QBLG4</Code>
+                <Description>Diastolic BP</Description>
+            </ObservationCode>
+            <ObservationValue>100</ObservationValue>
+            <ObservationUnits>mmHg</ObservationUnits>
+            <PrePost>PRE</PrePost>
+            <EnteredAt>
+                <CodingStandard>RR1+</CodingStandard>
+                <Code>ABC123</Code>
+                <Description>Test Hospital</Description>
+            </EnteredAt>
+            <EnteringOrganization>
+                <CodingStandard>RR1+</CodingStandard>
+                <Code>ABC123</Code>
+                <Description>Test Hospital</Description>
+            </EnteringOrganization>
+            <UpdatedOn>2006-05-04T18:13:51.0</UpdatedOn>
+            <ExternalId>7777777777</ExternalId>
+        </Observation>
+    </Observations>
+
+    <Diagnoses>
+        <Diagnosis>
+            <Diagnosis>
+                <CodingStandard>SNOMED</CodingStandard>
+                <Code>414545008</Code>
+                <Description>Ischaemic Heart Disease</Description>
+            </Diagnosis>
+            <IdentificationTime>2006-05-04T18:13:51.0</IdentificationTime>
+            <OnsetTime>2006-05-04T18:13:51.0</OnsetTime>
+            <EnteredOn>2006-05-04T18:13:51.0</EnteredOn>
+            <UpdatedOn>2006-05-04T18:13:51.0</UpdatedOn>
+            <ExternalId>5555555555</ExternalId>
+        </Diagnosis>
+        <Diagnosis>
+            <Diagnosis>
+                <CodingStandard>SNOMED</CodingStandard>
+                <Code>235856003</Code>
+                <Description>Liver Disease</Description>
+            </Diagnosis>
+            <IdentificationTime>2006-05-04T18:13:51.0</IdentificationTime>
+            <OnsetTime>2006-05-04T18:13:51.0</OnsetTime>
+            <EnteredOn>2006-05-04T18:13:51.0</EnteredOn>
+            <UpdatedOn>2006-05-04T18:13:51.0</UpdatedOn>
+            <ExternalId>778787876878</ExternalId>
+        </Diagnosis>
+        <CauseOfDeath>
+            <DiagnosisType>PRIMARY</DiagnosisType><Diagnosis>
+                <CodingStandard>EDTA_COD</CodingStandard>
+                <Code>14</Code>
+                <Description>Other causes of cardiac failure</Description>
+            </Diagnosis>
+            <Comments>Comments15</Comments>
+            <EnteredOn>2006-05-04T18:13:51.0</EnteredOn>
+            <UpdatedOn>2006-05-04T18:13:51.0</UpdatedOn>
+            <ExternalId>211111221</ExternalId>
+        </CauseOfDeath>
+        <RenalDiagnosis>
+            <DiagnosisType>PRIMARY</DiagnosisType><Diagnosis>
+                <CodingStandard>EDTA2</CodingStandard>
+                <Code>13</Code>
+                <Description>Dense deposite disease, membrano-prolif. GN Type II</Description>
+            </Diagnosis>
+            <Comments>Comments16</Comments>
+            <IdentificationTime>2006-05-04T18:13:51.0</IdentificationTime>
+            <OnsetTime>2006-05-04T18:13:51.0</OnsetTime>
+            <EnteredOn>2006-05-04T18:13:51.0</EnteredOn>
+            <UpdatedOn>2006-05-04T18:13:51.0</UpdatedOn>
+            <ExternalId>433444333222</ExternalId>
+        </RenalDiagnosis>
+    </Diagnoses>
+
+    <Medications>
+        <Medication>
+            <FromTime>2006-05-04T18:13:51.0</FromTime>
+            <ToTime>2006-05-04T18:13:51.0</ToTime>
+            <Route>
+                <CodingStandard>RR22</CodingStandard>
+                <Code>1</Code>
+                <Description>Oral</Description>
+            </Route>
+            <DrugProduct>
+                <Generic>Generic0</Generic>
+                <LabelName>LabelName0</LabelName>
+                <Form>
+                    <CodingStandard>SNOMED</CodingStandard>
+                    <Code>Code60</Code>
+                    <Description>Description60</Description>
+                </Form>
+                <StrengthUnits>
+                    <CodingStandard>CF_RR23</CodingStandard>
+                    <Code>l</Code>
+                    <Description>Description61</Description>
+                </StrengthUnits>
+            </DrugProduct>
+            <Frequency>Frequency0</Frequency>
+            <Comments>Comments17</Comments>
+            <DoseQuantity>0</DoseQuantity>
+            <DoseUoM>
+                <CodingStandard>CodingStandard62</CodingStandard>
+                <Code>Code62</Code>
+                <Description>Description62</Description>
+            </DoseUoM>
+            <Indication>Indication0</Indication>
+            <EncounterNumber>EncounterNumber2</EncounterNumber>
+            <UpdatedOn>2006-05-04T18:13:51.0</UpdatedOn>
+            <ExternalId>ExternalId15</ExternalId>
+        </Medication>
+    </Medications>
+
+    <Procedures>
+        <DialysisSessions>
+            <DialysisSession>
+                <ProcedureType>
+                    <CodingStandard>SNOMED</CodingStandard>
+                    <Code>302497006</Code>
+                    <Description>Haemodialysis</Description>
+                </ProcedureType>
+                <ProcedureTime>2006-05-04T18:13:51.0</ProcedureTime>
+                <EnteredBy>
+                    <CodingStandard>ODS</CodingStandard>
+                    <Code>ABC123</Code>
+                    <Description>Dr Foster</Description>
+                </EnteredBy>
+                <EnteredAt>
+                    <CodingStandard>RR1+</CodingStandard>
+                    <Code>ABC123</Code>
+                    <Description>Test Hospital</Description>
+                </EnteredAt>
+                <UpdatedOn>2006-05-04T18:13:51.0</UpdatedOn>
+                <ExternalId>787878787</ExternalId>
+                <SymtomaticHypotension>Y</SymtomaticHypotension><VascularAccess><Code>NLN</Code></VascularAccess><VascularAccessSite><Code>BB</Code></VascularAccessSite><TimeDialysed>200</TimeDialysed></DialysisSession>
+            <DialysisSession>
+                <ProcedureType>
+                    <CodingStandard>SNOMED</CodingStandard>
+                    <Code>Code82</Code>
+                    <Description>Description82</Description>
+                </ProcedureType>
+                <ProcedureTime>2006-05-04T18:13:51.0</ProcedureTime>
+                <EnteredBy>
+                    <CodingStandard>ODS</CodingStandard>
+                    <Code>Code84</Code>
+                    <Description>Description84</Description>
+                </EnteredBy>
+                <EnteredAt>
+                    <CodingStandard>ODS</CodingStandard>
+                    <Code>Code85</Code>
+                    <Description>Description85</Description>
+                </EnteredAt>
+                <UpdatedOn>2006-05-04T18:13:51.0</UpdatedOn>
+                <ExternalId>ExternalId20</ExternalId>
+                <SymtomaticHypotension>Y</SymtomaticHypotension><VascularAccess><Code>NLN</Code></VascularAccess><VascularAccessSite><Code>BB</Code></VascularAccessSite><TimeDialysed>200</TimeDialysed></DialysisSession>
+        </DialysisSessions>
+        <Transplant>
+            <ProcedureType>
+                <CodingStandard>SNOMED</CodingStandard>
+                <Code>19647005</Code>
+                <Description>PEX</Description>
+            </ProcedureType>
+            <ProcedureTime>2006-05-04T18:13:51.0</ProcedureTime>
+            <EnteredBy>
+                <CodingStandard>ODS</CodingStandard>
+                <Code>ABC123</Code>
+                <Description>Dr Foster</Description>
+            </EnteredBy>
+            <EnteredAt>
+                <CodingStandard>RR1+</CodingStandard>
+                <Code>ABC123</Code>
+                <Description>Test Hospital</Description>
+            </EnteredAt>
+            <UpdatedOn>2006-05-04T18:13:51.0</UpdatedOn>
+            <ExternalId>1222333444</ExternalId>
+            </Transplant>
+        <VascularAccess>
+            <ProcedureType>
+                <CodingStandard>SNOMED</CodingStandard>
+                <Code>27929005</Code>
+                <Description>Construction of arteriovenous fistula</Description>
+            </ProcedureType>
+            <ProcedureTime>2006-05-04T18:13:51.0</ProcedureTime>
+            <EnteredBy>
+                <CodingStandard>ODS</CodingStandard>
+                <Code>ABC123</Code>
+                <Description>Dr Foster</Description>
+            </EnteredBy>
+            <EnteredAt>
+                <CodingStandard>RR1+</CodingStandard>
+                <Code>ABC123</Code>
+                <Description>Test Hospital</Description>
+            </EnteredAt>
+            <UpdatedOn>2006-05-04T18:13:51.0</UpdatedOn>
+            <ExternalId>1111111111</ExternalId>
+            <Attributes>
+                <ACC19>2006-05-04T18:13:51.0</ACC19>
+                <ACC20>2006-05-04T18:13:51.0</ACC20>
+                <ACC21>2006-05-04T18:13:51.0</ACC21>
+                <ACC22>100</ACC22>
+                <ACC30>1</ACC30>
+                <ACC40>300</ACC40>
+            </Attributes>
+        </VascularAccess>
+    </Procedures>
+
+    <Documents>
+        <Document>
+            <DocumentTime>2006-05-04T18:13:51.0</DocumentTime>
+            <NoteText>This is some plain text.</NoteText>
+            <DocumentName>GP Letter</DocumentName>
+            <FileType>text/plain</FileType>
+            <FileName>letter.txt</FileName>
+            <UpdatedOn>2006-05-04T18:13:51.0</UpdatedOn>
+            <ExternalId>1111111111</ExternalId>
+        </Document>
+    </Documents>
+
+    <Encounters>
+        <Treatment>
+            <FromTime>2006-05-04</FromTime>
+            <ToTime>2021-05-04</ToTime>
+            <HealthCareFacility>
+                <CodingStandard>RR1+</CodingStandard>
+                <Code>ABC123</Code>
+                <Description>Test Hospital</Description>
+            </HealthCareFacility>
+            <AdmitReason>
+                <CodingStandard>CF_RR7_TREATMENT</CodingStandard>
+                <Code>1</Code>
+                <Description>Haemodialysis</Description>
+            </AdmitReason>
+            <AdmissionSource>
+                <CodingStandard>RR1+</CodingStandard>
+                <Code>ABROAD</Code>
+                <Description>ABROAD</Description>
+            </AdmissionSource>
+            <DischargeReason>
+                <CodingStandard>CF_RR7_DISCHARGE</CodingStandard>
+                <Code>38</Code>
+                <Description>Patient Transferred Out</Description>
+            </DischargeReason>
+            <DischargeLocation>
+                <CodingStandard>RR1+</CodingStandard>
+                <Code>AAA111</Code>
+                <Description>Another Hospital</Description>
+            </DischargeLocation>
+            <Attributes>
+                <QBL05>INCENTRE</QBL05>
+                </Attributes>
+            <UpdatedOn>2006-05-04T18:13:51.0</UpdatedOn>
+            <ExternalId>3343433432234</ExternalId>
+        </Treatment>
+    </Encounters>
+
+</ukrdc:PatientRecord>


### PR DESCRIPTION
There  are a few key differences between v4 and v5 of the schema. 

## Two new elements: 
Assessments 
DialysisPrescriptions 

- [ ] Basic support to load Assessments
- [ ] Basic support to load Dialysis Prescriptions  

What is the plan with these? will they be added as tables to the database and added to the sqla models? The Dialysis Prescriptions seem like something that could be integrated into medications. 

## Remapped and removed Elements
We may be able to make life slightly easier by using the aliases in sqla here 
- [ ] Attributes of Dialysis sessions have been remapped in the xml 
- [ ] Transplant elements have been remapped
- [ ] Procedures/Procedure/Clinician
- [ ] Procedures/DialysisSessions/DialysisSession/   "Clinician", "Attributes"
- [ ] Observations/Observation/Clinician
- [ ] Medications/Medication/OrderedBy
- [ ] Diagnoses/Diagnosis/EnteredAt



## Optional elements required in v4 schema 
- [ ] Assessments/AssessmentType
- [ ]  Diagnoses/CauseOfDeath/DiagnosisType, Diagnosis
- [ ] Diagnoses/Diagnosis
- [ ]  ...



